### PR TITLE
update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,11 @@ secrets.json
 *.env
 *.log
 *.md5
+*.txt
+*.TXT
+*.json
+*.JSON
+
 *CHISTORY.TXT
+EVENTS
 >>>>>>> ot-dev-ftp-meter-download


### PR DESCRIPTION
added the EVENTS directory to ensure no downloade files are pushed to github. I also left all the file extensions in the file because the local download path is not hardcoded so if it is changed EVENTS will no longer be relevant. But we expect EVENTS to be the default