### PR TITLE
Checksum and Zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Ensure you have the following before running the pipeline:
     - `lftp` — FTP operations
     - `jq` — JSON metadata
     - `yq` - YAML config files
+    - `sudo apt-get install zip`
 
 ## Installation
 1. You must be connected to the `ot-dev` server. See **OT-dev(SSH)** in the [ACEP Wiki](https://wiki.acep.uaf.edu/en/teams/data-ducts/aetb).


### PR DESCRIPTION
I added a checksum for the event (checksum for all event files and metadata in the dir) and a zip command to the event dir, including all five files, metadata, and checksum. This is all done after it is confirmed that all files were indeed successfully downloaded in the event dir.