### PR TITLE
Fixes for cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SEL-735 Meter Event Data Pipeline (IN PROGRESS 03/13/24)
 
-This repository contains a set of ```Bash scripts that make up a data pipeline, designed to automate the process of interacting with an SEL-735 meter. The pipeline **currently** handles:
+This repository contains a set of Bash scripts that make up a data pipeline, designed to automate the process of interacting with an SEL-735 meter. The pipeline **currently** handles:
 - Connecting to the meter via FTP
 - Checking for new event files
 - Downloading event files
@@ -21,19 +21,18 @@ Ensure you have the following before running the pipeline:
 ## Installation
 1. You must be connected to the `ot-dev` server. See **OT-dev(SSH)** in the [ACEP Wiki](https://wiki.acep.uaf.edu/en/teams/data-ducts/aetb).
  
-2. Clone the repository and prepare the scripts:
+2. Clone the repository:
 
-    ``````bash
-    git clone git@github.com:acep-uaf/data-ducks-STREAM.git
-    cd data-ducks-STREAM/cli_meter
-    chmod +x *.sh
+    ```bash
+    git clone git@github.com:acep-uaf/camio-meter-streams.git
+    cd camio-meter-streams/cli_meter
     ```
     **Note**: You can check your SSH connection with `ssh -T git@github.com`
 
 ## Configuration
 1. Navigate and copy the `config.yml.example` file to a new `config.yml` file:
 
-    ``````bash
+    ```bash
     cp config.yml.example config.yml
     ```
 
@@ -41,7 +40,7 @@ Ensure you have the following before running the pipeline:
 
 3. Secure the `config.yml` file so that only the owner can read and write:
 
-    ``````bash
+    ```bash
     chmod 600 config.yml
     ```
 
@@ -50,7 +49,7 @@ To run the data pipeline, you must have admin privileges and execute the script 
 
 ### Basic Command
 ```bash
-sudo ./data_pipeline.sh
+ ./data_pipeline.sh
 ```
 This command runs the script with default settings, where it looks for the configuration file at /etc/acep-data-streams/config.yml and determines the download directory based on the settings within the config file.
 
@@ -62,12 +61,12 @@ This command runs the script with default settings, where it looks for the confi
 Use the --config (or -c for short) flag to specify a custom path to the configuration file.
 
 ```bash
-sudo ./data_pipeline.sh --config /path/to/config.yml
+./data_pipeline.sh --config /path/to/config.yml
 ```
 Or using the short form:
 
 ```bash
-sudo ./data_pipeline.sh -c /path/to/config.yml
+./data_pipeline.sh -c /path/to/config.yml
 ```
 #### Download Directory
 `--download_dir or -d`
@@ -75,23 +74,23 @@ sudo ./data_pipeline.sh -c /path/to/config.yml
 Use the --download_dir (or -d for short) flag to specify a custom download directory. This directory will be used to store the downloaded data, overriding the directory specified in the configuration file.
 
 ```bash
-sudo ./data_pipeline.sh --download_dir /path/to/download_directory
+./data_pipeline.sh --download_dir /path/to/download_directory
 ```
 Or using the short form:
 
 ```bash
-sudo ./data_pipeline.sh -d /path/to/download_directory
+./data_pipeline.sh -d /path/to/download_directory
 ```
 ### Combining Flags
 You can combine both flags to customize both the configuration file path and the download directory:
 
 ```bash
-sudo ./data_pipeline.sh --config /path/to/config.yml --download_dir /path/to/download_directory
+./data_pipeline.sh --config /path/to/config.yml --download_dir /path/to/download_directory
 ```
 Or using short forms:
 
 ```bash
-sudo ./data_pipeline.sh -c /path/to/config.yml -d /path/to/download_directory
+./data_pipeline.sh -c /path/to/config.yml -d /path/to/download_directory
 ```
 
 **Note:** Order of flags does not matter and you can use short and long form together.
@@ -102,27 +101,27 @@ Manage file transfers with rsync_stream.service. Use `systemctl` to start, stop,
 **Service**: `rsync_stream.service` (see `stream.sh`)
 
 **Start**
-``````bash
+```bash
 sudo systemctl start your-service-name.service
 ```
 
 **Stop**
-``````bash
+```bash
 sudo systemctl stop your-service-name.service
 ```
 
 **Enable on Boot**
-``````bash
+```bash
 sudo systemctl enable your-service-name.service
 ```
 
 **Disable on Boot**
-``````bash
+```bash
 sudo systemctl disable your-service-name.service
 ```
 
 **Status**
-``````bash
+```bash
 sudo systemctl status your-service-name.service
 ```
 

--- a/cli_meter/commons.sh
+++ b/cli_meter/commons.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-##################################
-#
-# This sourced by data_pipeline.sh
-#
-#################################
+# This sourced by data_pipeline.sh and contains common functions used by other scripts
 
 fail() {
-  echo "$1" >&2
+  echo "[ERROR] $1" >&2
   exit 1
 }
 

--- a/cli_meter/commons.sh
+++ b/cli_meter/commons.sh
@@ -6,22 +6,15 @@
 #
 #################################
 
-log() {
-    local priority=${2:-info}
-    local tag="STREAM"
-
-    # This will send the message to stderr
-    #echo "$1" >&2
-
-    # This will send the message to the systemd journal with a dynamic priority
-    logger -p user.$priority -t "$tag" "$1"
-}
-
-# Function to exit script with an error message
-exit_with_error() {
+fail() {
   echo "$1" >&2
   exit 1
 }
 
+# Output message to stdout & stderr
+log() {
+  echo "$1" >&2
+}
+
 export -f log
-export -f exit_with_error
+export -f fail

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -4,6 +4,9 @@ current_dir=$(dirname "$(readlink -f "$0")")
 # Source the commons.sh file
 source "$current_dir/commons.sh"
 
+# Set up trap for SIGINT
+trap "fail 'Operation interupted by SIGINT'" SIGINT
+
 config_path=""
 download_dir="" # To be potentially overriden by flags
 
@@ -34,6 +37,9 @@ fi
 # Read values from the config file if not overridden by command-line args
 if [ -z "$download_dir" ]; then
     download_dir=$(yq '.download_directory' "$config_path")
+    if [ -z "$download_dir" ]; then
+        fail "Config: Download directory cannot be null or empty, check config or add the download flag -d"
+    fi
 fi
 
 # Read the config file

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # Source the commons.sh file
-source commons.sh
+current_dir=$(dirname "$(readlink -f "$0")")
+
+source "$current_dir/commons.sh"
 
 config_path="/etc/acep-data-streams/config.yml"
 download_dir="" # To be potentially overriden by flags
@@ -77,10 +79,8 @@ for ((i = 0; i < num_meters; i++)); do
     export USERNAME=${meter_username:-$default_username}
     export PASSWORD=${meter_password:-$default_password}
 
-    current_dir=$(dirname "$(readlink -f "$0")")
-
     # Execute download script
-    "meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" 
+    "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" 
 
     echo "Processing complete for meter: $meter_id"
 done

--- a/cli_meter/meters/sel735/commons.sh
+++ b/cli_meter/meters/sel735/commons.sh
@@ -1,0 +1,64 @@
+handle_sigint() {
+    log "" # Newline for readability
+    # Mark event incomplete if event_id is set
+    if [ -n "$current_event_id" ]; then
+        local output_dir="$base_output_dir/$date_dir/$meter_id"
+        mark_event_incomplete "$current_event_id" "$output_dir"
+    else
+        log "current_event_id is not set, no event to move to .incomplete."
+    fi
+
+    fail "Operating interupted by SIGINT"
+}
+
+# Mark event as incomplete
+mark_event_incomplete() {
+  local event_id="$1"
+  local original_dir="$2/$event_id"
+  
+  # Initialize the base name for incomplete directories
+  local base_incomplete_dir="${original_dir}.incomplete"
+
+  # Check if the original directory exists
+  if [ -d "$original_dir" ]; then
+    # Find an available suffix or the one to rotate
+    local suffix=1
+    while [ -d "${base_incomplete_dir}_${suffix}" ]; do
+      let suffix++
+      # If reaching the 6th iteration, start rotation from 1
+      if [ "$suffix" -gt 5 ]; then
+        suffix=5
+        break
+      fi
+    done
+
+    # Remove the oldest if going to exceed 5 directories
+    if [ -d "${base_incomplete_dir}_5" ]; then
+      rm -rf "${base_incomplete_dir}_1"
+      # Shift remaining directories
+      for ((i=2; i<=5; i++)); do
+        mv "${base_incomplete_dir}_$i" "${base_incomplete_dir}_$((i-1))"
+      done
+    fi
+
+    # Move the current directory to its new incomplete name
+    mv "$original_dir" "${base_incomplete_dir}_${suffix}"
+    log "Moved event $event_id to ${base_incomplete_dir}_${suffix}"
+  else
+    echo "Error: Directory $original_dir does not exist."
+  fi
+}
+
+# Function to check if all files for an event have been downloaded
+validate_download() {
+    local event_dir=$1
+    local event_id=$2
+    # Files expect to have downloaded
+    local expected_files=("CEV_${event_id}.CEV" "HR_${event_id}.CFG" "HR_${event_id}.DAT" "HR_${event_id}.HDR" "HR_${event_id}.ZDAT")
+    for file in "${expected_files[@]}"; do
+        if [ ! -f "${event_dir}/${file}" ]; then
+            return 0 # File is missing
+        fi
+    done
+    return 1 # All files are present
+}

--- a/cli_meter/meters/sel735/commons.sh
+++ b/cli_meter/meters/sel735/commons.sh
@@ -1,5 +1,4 @@
 handle_sigint() {
-    log "" # Newline for readability
     # Mark event incomplete if event_id is set
     if [ -n "$current_event_id" ]; then
         local output_dir="$base_output_dir/$date_dir/$meter_id"
@@ -8,7 +7,6 @@ handle_sigint() {
         log "current_event_id is not set, no event to move to .incomplete."
     fi
 
-    fail "Operating interupted by SIGINT"
 }
 
 # Mark event as incomplete
@@ -43,9 +41,10 @@ mark_event_incomplete() {
 
     # Move the current directory to its new incomplete name
     mv "$original_dir" "${base_incomplete_dir}_${suffix}"
-    log "Moved event $event_id to ${base_incomplete_dir}_${suffix}"
+    log "" # Add a new line for better readability
+    log "Moved event $event_id to ${event_id}.incomplete_${suffix}"
   else
-    echo "Error: Directory $original_dir does not exist."
+    log "[ERROR] Directory $original_dir does not exist."
   fi
 }
 

--- a/cli_meter/meters/sel735/create_metadata_yml.sh
+++ b/cli_meter/meters/sel735/create_metadata_yml.sh
@@ -12,16 +12,15 @@
 
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 6 ]; then
-    echo "Usage: $0 <file> <event_dir> <meter_id> <meter_type> <meter_download_timestamp> <otdev_download_timestamp>"
-    exit 1
+    fail "Usage: $0 <file> <event_dir> <meter_id> <meter_type> <event_timestamp> <download_timestamp>"
 fi
 
 file=$1
 event_dir=$2
 meter_id=$3
 meter_type=$4
-meter_download_timestamp=$5
-otdev_download_timestamp=$6
+event_timestamp=$5
+download_timestamp=$6
 
 # Extract the event ID from the directory name or another source if it is available differently
 event_id=$(basename "$event_dir")
@@ -41,17 +40,17 @@ log "Starting metadata generation for file: $filename"
 # Append metadata to the YAML file
 if {
     echo "- File: $filename"
-    echo "  DownloadedAt: \"$otdev_download_timestamp\""
-    echo "  MeterEventDate: \"$meter_download_timestamp\""
+    echo "  DownloadedAt: \"$download_timestamp\""
+    echo "  MeterEventDate: \"$event_timestamp\""
     echo "  MeterID: \"$meter_id\""
-    echo "  MeterType: \"$meter_type\"" 
+    echo "  MeterType: \"$meter_type\""
     echo "  EventID: \"$event_id\""
     echo "  DataLevel: \"level0\""
     echo "  Checksum: \"$checksum\""
 } >> "$metadata_path"; then
     log "Metadata updated for: $filename"
-    return 0  # Exit with success code
+    return 0 # Exit with success code
 else
-    log "Error updating metadata for file: $filename" "err"
-    return 1  # Exit with error code
+    log "Error updating metadata for file: $filename"
+    return 1 # Exit with error code
 fi

--- a/cli_meter/meters/sel735/create_metadata_yml.sh
+++ b/cli_meter/meters/sel735/create_metadata_yml.sh
@@ -35,8 +35,6 @@ checksum=$(md5sum "$file" | awk '{print $1}')
 # Append the checksum and filename to a checksum.md5 file in the event directory
 echo "$checksum $filename" >> "$event_dir/checksum.md5"
 
-log "Starting metadata generation for file: $filename"
-
 # Append metadata to the YAML file
 if {
     echo "- File: $filename"
@@ -48,9 +46,9 @@ if {
     echo "  DataLevel: \"level0\""
     echo "  Checksum: \"$checksum\""
 } >> "$metadata_path"; then
-    log "Metadata updated for: $filename"
+    log "Metadata generated for: $filename"
     return 0 # Exit with success code
 else
-    log "Error updating metadata for file: $filename"
+    log "Error generating metadata for: $filename"
     return 1 # Exit with error code
 fi

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -3,51 +3,9 @@
 #
 #
 #################################
-
-########### FUNCTIONS ##########################################################################
-handle_sigint() {
-  # Mark event incomplete if event_id is set
-  if [ -n "$current_event_id" ]; then
-    local output_dir="$base_output_dir/$date_dir/$meter_id"
-    mark_event_incomplete "$current_event_id" "$output_dir"
-  else
-    log "current_event_id is not set, no event to move to .incomplete."
-  fi
-
-  fail "Operating interupted by SIGINT, exiting..."
-}
-
-# Mark event as incomplete
-mark_event_incomplete() {
-  log "Marking event as incomplete..."
-  local event_id="$1"
-  local original_dir="$2/$event_id"
-  local incomplete_dir="$original_dir.incomplete_$(date -u +"%Y-%m-%dT%H:%M:%S")"
-
-  # Check if the original directory exists
-  if [ -d "$original_dir" ]; then
-    mv "$original_dir" "$incomplete_dir"
-    log "Moved event $event_id to .incomplete"
-  else
-    echo "Error: Directory $original_dir does not exist."
-  fi
-}
-
-# Function to check if all files for an event have been downloaded
-validate_download() {
-  local event_dir=$1
-  local event_id=$2
-  # Assuming these are the files you expect to have downloaded
-  local expected_files=("CEV_${event_id}.CEV" "HR_${event_id}.CFG" "HR_${event_id}.DAT" "HR_${event_id}.HDR" "HR_${event_id}.ZDAT")
-  for file in "${expected_files[@]}"; do
-    if [ ! -f "${event_dir}/${file}" ]; then
-      return 0 # File is missing
-    fi
-  done
-  return 1 # All files are present
-}
-###############################################################################################
-
+current_dir=$(dirname "$(readlink -f "$0")")
+current_event_id=""
+source "$current_dir/commons.sh"
 trap handle_sigint SIGINT
 
 # Check for exactly 4 arguments
@@ -62,9 +20,6 @@ base_zipped_output_dir="$2/level0"
 meter_id="$3"
 meter_type="$4"
 
-current_dir=$(dirname "$(readlink -f "$0")")
-current_event_id=""
-
 # Make dir if it doesn't exist
 mkdir -p "$base_output_dir"
 
@@ -76,16 +31,17 @@ loop_success=true
 
 # output_dir is the location where the data will be stored
 for event_info in $($current_dir/get_events.sh "$meter_ip" "$meter_id" "$base_output_dir"); do
-  # Split the output into event_id and formatted_date
+
+  # Split the output into variables
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"
 
-  # Update current_event_id for the cleanup function
+  # Update current_event_id for mark_event_incomplete()
   current_event_id=$event_id
 
-  # Update output_dir and download event
+  # Update output_dir
   output_dir="$base_output_dir/$date_dir/$meter_id"
 
-  # download_event downloads 5 files for each event
+  # Download event directory (5 files)
   source "$current_dir/download_event.sh" "$meter_ip" "$event_id" "$output_dir"
 
   # Check if download_event.sh was successful before creating metadata

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -4,8 +4,9 @@
 #
 #################################
 current_dir=$(dirname "$(readlink -f "$0")")
-current_event_id=""
 source "$current_dir/commons.sh"
+export current_event_id=""
+
 trap handle_sigint SIGINT
 
 # Check for exactly 4 arguments
@@ -36,7 +37,7 @@ for event_info in $($current_dir/get_events.sh "$meter_ip" "$meter_id" "$base_ou
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"
 
   # Update current_event_id for mark_event_incomplete()
-  current_event_id=$event_id
+  export current_event_id=$event_id
 
   # Update output_dir
   output_dir="$base_output_dir/$date_dir/$meter_id"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -37,7 +37,7 @@ for event_info in $($current_dir/get_events.sh "$meter_ip" "$meter_id" "$base_ou
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"
 
   # Update current_event_id for mark_event_incomplete()
-  export current_event_id=$event_id
+  current_event_id=$event_id
 
   # Update output_dir
   output_dir="$base_output_dir/$date_dir/$meter_id"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -1,10 +1,38 @@
 #!/bin/bash
 #################################
-# 
+#
 #
 #################################
-########### FUNCTIONS ###########
-###############################################################################################
+
+########### FUNCTIONS ##########################################################################
+handle_sigint() {
+  # Mark event incomplete if event_id is set
+  if [ -n "$current_event_id" ]; then
+    local output_dir="$base_output_dir/$date_dir/$meter_id"
+    mark_event_incomplete "$current_event_id" "$output_dir"
+  else
+    log "current_event_id is not set, no event to move to .incomplete."
+  fi
+
+  fail "Operating interupted by SIGINT, exiting..."
+}
+
+# Mark event as incomplete
+mark_event_incomplete() {
+  log "Marking event as incomplete..."
+  local event_id="$1"
+  local original_dir="$2/$event_id"
+  local incomplete_dir="$original_dir.incomplete_$(date -u +"%Y-%m-%dT%H:%M:%S")"
+
+  # Check if the original directory exists
+  if [ -d "$original_dir" ]; then
+    mv "$original_dir" "$incomplete_dir"
+    log "Moved event $event_id to .incomplete"
+  else
+    echo "Error: Directory $original_dir does not exist."
+  fi
+}
+
 # Function to check if all files for an event have been downloaded
 validate_download() {
   local event_dir=$1
@@ -20,33 +48,28 @@ validate_download() {
 }
 ###############################################################################################
 
+trap handle_sigint SIGINT
 
 # Check for exactly 4 arguments
 if [ "$#" -ne 4 ]; then
-  echo "Usage: $0 <meter_ip> <output_dir> <meter_id> <meter_type>"
-  exit 1
+  fail "Usage: $0 <meter_ip> <output_dir> <meter_id> <meter_type>"
 fi
 
 # Simple CLI flag parsing
 meter_ip="$1"
-base_output_dir="$2/working" # Assumes LOCATION/DATA_TYPE/YYYY-MM/METER_ID
-base_zipped_output_dir="$2/level0" # Assumes LOCATION/DATA_TYPE/YYYY-MM/METER_ID
+base_output_dir="$2/working"
+base_zipped_output_dir="$2/level0"
 meter_id="$3"
 meter_type="$4"
 
-# Directory where this script is located (not the same as pwd because data_pipeline.sh is in another dir)
-current_dir=$(dirname "${0}")
+current_dir=$(dirname "$(readlink -f "$0")")
+current_event_id=""
+
 # Make dir if it doesn't exist
 mkdir -p "$base_output_dir"
 
 # Test connection to meter
 source "$current_dir/test_meter_connection.sh" "$meter_ip"
-
-# Check if test_meter_connection.sh was successful
-if [ $? -ne 0 ]; then
-  echo "Connection to meter at $meter_ip failed."
-  exit 1
-fi
 
 # Initialize a flag to indicate the success of the entire loop process
 loop_success=true
@@ -55,12 +78,14 @@ loop_success=true
 for event_info in $($current_dir/get_events.sh "$meter_ip" "$meter_id" "$base_output_dir"); do
   # Split the output into event_id and formatted_date
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"
+
   # Update current_event_id for the cleanup function
   current_event_id=$event_id
+
   # Update output_dir and download event
   output_dir="$base_output_dir/$date_dir/$meter_id"
 
-  # download_event downloads 5 files for each event 
+  # download_event downloads 5 files for each event
   source "$current_dir/download_event.sh" "$meter_ip" "$event_id" "$output_dir"
 
   # Check if download_event.sh was successful before creating metadata
@@ -68,35 +93,30 @@ for event_info in $($current_dir/get_events.sh "$meter_ip" "$meter_id" "$base_ou
     # Timestamp is time this script is run.
     download_timestamp=$(date --iso-8601=seconds)
 
-      # If all files are downloaded successfully generate metadata/checksum then zip
-      if validate_download "$output_dir" "$event_id"; then
-        # Generate metadata and checksums of files for the event
-        source "$current_dir/generate_event_metadata.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_timestamp"
+    # If all files are downloaded successfully generate metadata/checksum then zip
+    if validate_download "$output_dir" "$event_id"; then
+      # Generate metadata and checksums of files for the event
+      source "$current_dir/generate_event_metadata.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_timestamp"
 
-        # Zip the event directory, including all files and the checksum.md5 file
-        event_zipped_output_dir="$base_zipped_output_dir/$date_dir/$meter_id"
-        mkdir -p "$event_zipped_output_dir"
-        source "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id"
+      # Zip the event directory, including all files and the checksum.md5 file
+      event_zipped_output_dir="$base_zipped_output_dir/$date_dir/$meter_id"
+      mkdir -p "$event_zipped_output_dir"
+      source "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id"
 
-      else
-        #TODO: handle this case
-        echo "Not all files downloaded for event_id: $event_id"
-        log "Not all files downloaded for event: $event_id" "warn"
-        loop_success=false
-      fi
+    else
+      #TODO: handle this case
+      log "Not all files downloaded for event: $event_id"
+      loop_success=false
+    fi
   else
-    echo "Download failed for event_id: $event_id, skipping metadata creation."
-    log "Download failed for event_id: $event_id, skipping metadata creation." "warn"
+    log "Download failed for event_id: $event_id, skipping metadata creation."
     loop_success=false
   fi
 done
 
-
 # After the loop, check the flag and log accordingly
 if [ "$loop_success" = true ]; then
-  echo "Successfully downloaded all events."
   log "Successfully downloaded all events."
 else
-  echo "Finished downloaded with some errors. Check logs for more information."
-  log "Finished downloaded with some errors." "err"
+  log "Finished downloaded with some errors."
 fi

--- a/cli_meter/meters/sel735/download_event.sh
+++ b/cli_meter/meters/sel735/download_event.sh
@@ -2,46 +2,37 @@
 
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <meter_ip> <event_id> <output_dir>"
-    exit 1
+    fail "Usage: $0 <meter_ip> <event_id> <output_dir>"
 fi
 
 # Extracting arguments into variables
 meter_ip=$1
 event_id=$2
-download_dir="$3/$event_id" # Assumes $3 = /../location/data_type/YYYY-MM/METER_ID
-download_progress_dir="$3/.download_progress"
+download_dir="$3/$event_id" # Assumes $3 = /../location/data_type/YYYY-MM/METER_ID/working
 remote_dir="EVENTS"
-
-# LOCATION/DATA_TYPE/YYYY-MM/METER_ID/level0/
-
 
 # Create the local directory for this event if it doesn't exist
 mkdir -p "$download_dir"
 if [ $? -eq 0 ]; then
     log "Created local directory for event: $event_id"
 else
-    log "Failed to create local directory for event: $event_id" "err"
-    exit 1
+    fail "Failed to create local directory for event: $event_id"
 fi
 
-
 # Single lftp session
-lftp -u "$USERNAME,$PASSWORD" "$meter_ip" <<EOF
+lftp -u "$USERNAME,$PASSWORD" "$meter_ip" <<END_FTP_SESSION
 set xfer:clobber on
 cd $remote_dir
 lcd $download_dir
 mget *$event_id*.*
 bye
-EOF
+END_FTP_SESSION
 
 # Check the exit status of the lftp command
 if [ $? -eq 0 ]; then
     log "Download complete for event: $event_id"
-    echo "Download complete for event: $event_id"
 else
-    log "Failed to download files for event: $event_id" "err"
-    exit 1
+    fail "Failed to download files for event: $event_id"
 fi
 
 

--- a/cli_meter/meters/sel735/download_event.sh
+++ b/cli_meter/meters/sel735/download_event.sh
@@ -34,5 +34,3 @@ if [ $? -eq 0 ]; then
 else
     fail "Failed to download files for event: $event_id"
 fi
-
-

--- a/cli_meter/meters/sel735/generate_event_metadata.sh
+++ b/cli_meter/meters/sel735/generate_event_metadata.sh
@@ -2,7 +2,7 @@
 
 ##############################################################
 # This script:
-# - creates metadata 
+# - creates metadata
 # - is called from download.sh
 # - uses environment variables
 # - accepts 2 arguments: event_id and event_dir
@@ -17,7 +17,7 @@ if [ "$#" -ne 6 ]; then
 fi
 
 event_id=$1
-event_dir="$2/$event_id" # Assumes LOCATION/DATA_TYPE/YYYY-MM/working/METER_ID/
+event_dir="$2/$event_id" # Assumes location/data_type/working/YYYY-MM/meter_id/event_id
 meter_id=$3
 meter_type=$4
 event_timestamp=$5
@@ -31,14 +31,12 @@ for file in "$event_dir"/*; do
     if [ -f "$file" ] && [ -s "$file" ]; then
         # Source and check create_metadata_yml.sh
         source "$current_dir/create_metadata_yml.sh" "$file" "$event_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_timestamp"
-        
+
         if [ $? -ne 0 ]; then
             fail "create_metadata_yml.sh failed for: $file"
         fi
 
     else
-        fail "Error: No file found for $file"
+        fail "No file found for $file"
     fi
 done
-
-log "Metadata generated for event: $event_id"

--- a/cli_meter/meters/sel735/generate_event_metadata.sh
+++ b/cli_meter/meters/sel735/generate_event_metadata.sh
@@ -13,18 +13,15 @@ log "Creating metadata for event: $event_id"
 
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 6 ]; then
-    echo "Usage: $0 <event_id> <event_dir> <meter_id> <meter_type> <meter_download_timestamp> <otdev_download_timestamp>"
-    exit 1
+    fail "Usage: $0 <event_id> <event_dir> <meter_id> <meter_type> <event_timestamp> <download_timestamp>"
 fi
 
-
 event_id=$1
-event_dir="$2/$event_id" # Assumes LOCATION/DATA_TYPE/YYYY-MM/METER_ID/
+event_dir="$2/$event_id" # Assumes LOCATION/DATA_TYPE/YYYY-MM/working/METER_ID/
 meter_id=$3
 meter_type=$4
-meter_download_timestamp=$5
-otdev_download_timestamp=$6
-
+event_timestamp=$5
+download_timestamp=$6
 
 # Directory where this script is located (not the same as pwd because data_pipeline.sh is in another dir)
 current_dir=$(dirname "${0}")
@@ -33,13 +30,14 @@ current_dir=$(dirname "${0}")
 for file in "$event_dir"/*; do
     if [ -f "$file" ] && [ -s "$file" ]; then
         # Source and check create_metadata_yml.sh
-        source "$current_dir/create_metadata_yml.sh" "$file" "$event_dir" "$meter_id" "$meter_type" "$meter_download_timestamp" "$otdev_download_timestamp"
+        source "$current_dir/create_metadata_yml.sh" "$file" "$event_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_timestamp"
+        
         if [ $? -ne 0 ]; then
-            log "create_metadata_yml.sh failed for: $file" "err"
+            fail "create_metadata_yml.sh failed for: $file"
         fi
 
     else
-        log "Skipped: No file found for $file" "warn"
+        fail "Error: No file found for $file"
     fi
 done
 

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -16,7 +16,7 @@ meter_ip=$1
 meter_id=$2
 output_dir=$3
 
-files_per_event=6
+files_per_event=7
 remote_filename="CHISTORY.TXT"
 remote_dir="EVENTS"
 temp_dir_path="temp_dir.XXXXXX"
@@ -69,15 +69,14 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r line; do
 
         # Check if the event directory exists and has all the files
         if [ -d "$event_dir_path" ]; then
-            log "Event directory found: $event_id"
             non_empty_files_count=$(find "$event_dir_path" -type f ! -empty -print | wc -l)
-
+            
             if [ "$non_empty_files_count" -eq $files_per_event ]; then
                 log "Complete directory for event: $event_id"
 
             elif [ "$non_empty_files_count" -ne 0 ]; then
                 #TODO: Handle this case
-                log "Directoy exists, incomplete event: $event_id"
+                log "Incomplete directory for event: $event_id"
             fi
 
         else

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -9,8 +9,7 @@
 
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <meter_ip> <meter_id> <output_dir>"
-    exit 1
+    fail "Usage: $0 <meter_ip> <meter_id> <output_dir>"
 fi
 
 meter_ip=$1
@@ -29,20 +28,19 @@ temp_dir=$(mktemp -d $temp_dir_path)
 trap 'rm -rf "$temp_dir"' EXIT
 
 # Connect to meter and get CHISTORY.TXT
-lftp -u "$USERNAME,$PASSWORD" "$meter_ip" <<EOF
+lftp -u "$USERNAME,$PASSWORD" "$meter_ip" <<END_FTP_SESSION
 set xfer:clobber on
 cd $remote_dir
 lcd $temp_dir
 mget $remote_filename
 bye
-EOF
+END_FTP_SESSION
 
 # Check the exit status of lftp command
 if [ $? -eq 0 ]; then
     log "lftp session successful for: $(basename "$0")"
 else
-    log "lftp session failed for: $(basename "$0")" "err"
-    exit 1
+    fail "lftp session failed for: $(basename "$0")"
 fi
 
 # Path to CHISTORY.TXT in the temporary directory
@@ -50,8 +48,7 @@ temp_file_path="$temp_dir/$remote_filename"
 
 # Check if CHISTORY.TXT exists and is not empty
 if [ ! -f "$temp_file_path" ] || [ ! -s "$temp_file_path" ]; then
-    log "Download failed: $remote_filename. Could not find file: $temp_file_path" "err"
-    exit 1
+    fail "Download failed: $remote_filename. Could not find file: $temp_file_path"
 fi
 
 # Initialize a flag to indicate the success of the entire loop process
@@ -80,7 +77,7 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r line; do
 
             elif [ "$non_empty_files_count" -ne 0 ]; then
                 #TODO: Handle this case
-                log "Directoy exists, incomplete event: $event_id" "warn"
+                log "Directoy exists, incomplete event: $event_id"
             fi
 
         else
@@ -91,18 +88,16 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r line; do
         fi
 
     else
-        log "Skipping line: $line, not entirely numeric. Check parsing." "err"
+        fail "Skipping line: $line, not entirely numeric. Check parsing."
         loop_success=false
-        
+
     fi
-    
+
 done
 
 # After the loop, check the flag and log accordingly
 if [ "$loop_success" = true ]; then
-  log "Successfully processed all events."
+    log "Successfully processed all events."
 else
-  log "Finished processing with some errors." "err"
+    log "Finished processing with some errors."
 fi
-
-

--- a/cli_meter/meters/sel735/test_meter_connection.sh
+++ b/cli_meter/meters/sel735/test_meter_connection.sh
@@ -9,22 +9,18 @@
 
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <meter_ip>"
-    exit 1
+    fail "Usage: $0 <meter_ip>"
 fi
 
 # Logging in to the FTP server and checking the connection using lftp
 
 lftp_output=$(lftp -u $USERNAME,$PASSWORD -e "pwd; bye" $meter_ip)
-lftp_exit_status=$?
 
-if [ "$lftp_exit_status" -eq 0 ]; then
-    echo "Successful connection test to meter: $meter_ip"
+if [ "$?" -eq 0 ]; then
+    log "Successful connection test to meter: $meter_ip"
     return 0
 else
-    echo "The FTP service is not available, and the connection was not established. Check for multiple connections to the meter: $meter_ip"
-    log "FTP Server IP: $meter_ip is not available." "err"
-    return 1
+    fail "The FTP service is not available, and the connection was not established. Check for multiple connections to the meter: $meter_ip"
 fi
 
 

--- a/cli_meter/meters/sel735/test_meter_connection.sh
+++ b/cli_meter/meters/sel735/test_meter_connection.sh
@@ -22,5 +22,3 @@ if [ "$?" -eq 0 ]; then
 else
     fail "The FTP service is not available, and the connection was not established. Check for multiple connections to the meter: $meter_ip"
 fi
-
-

--- a/cli_meter/meters/sel735/zip_event.sh
+++ b/cli_meter/meters/sel735/zip_event.sh
@@ -15,8 +15,7 @@
 
 # Check for exactly 3 arguments
 if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <source_dir> <dest_dir> <event_id>"
-    exit 1
+    fail "Usage: $0 <source_dir> <dest_dir> <event_id>"
 fi
 
 source_dir="$1"
@@ -26,8 +25,7 @@ event_id="$3"
 zip -r -q "${dest_dir}/${event_id}.zip" "$source_dir"/* 
 
 if [ $? -eq 0 ]; then
-    echo "$event_id Validated and Zipped.--->"
+    log "Files validated and zipped for event: $event_id"
 else
-    echo "Error zipping files for $event_id"
-    exit 1
+    fail "Error zipping files for $event_id"
 fi

--- a/cli_meter/meters/sel735/zip_event.sh
+++ b/cli_meter/meters/sel735/zip_event.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 #########################################
-# This script zips the event files in the 
-# source directory and saves the zip file 
+# This script zips the event files in the
+# source directory and saves the zip file
 # in the destination directory.
-# 
+#
 # It takes 3 arguments:
 # 1. output dir: The directory containing the event files
 # 2. zipped output dir: The directory where the zip file will be saved
 # 3. event id: The ID of the event
 #
-# 
+#
 #########################################
-
 
 # Check for exactly 3 arguments
 if [ "$#" -ne 3 ]; then
@@ -22,10 +21,10 @@ source_dir="$1"
 dest_dir="$2"
 event_id="$3"
 
-zip -r -q "${dest_dir}/${event_id}.zip" "$source_dir"/* 
+zip -r -q "${dest_dir}/${event_id}.zip" "$source_dir"/*
 
 if [ $? -eq 0 ]; then
     log "Files validated and zipped for event: $event_id"
 else
-    fail "Error zipping files for $event_id"
+    fail "Zipping files for $event_id"
 fi


### PR DESCRIPTION
- Remove `logger` and  tag `STREAM` from log function
	- new log function `echo "$1" >&2`
- /meters/sel375/commons.sh
	- handle_sigint()
	- mark_event_incomplete()
	- validate_download()

- Add `trap fail SIGINT` to `data_pipeline.sh`, this calls exit 1
	- Add `trap handle_sigint` to `download.sh` to handle moving current event to .incomplete
- mark_event_incomplete()
	- moves current_event_id directory to .incomplete_#
	- rotates .incomplete directories after 5 `.incomplete`directories
- Change variable names
	- otdev_download_timestamp --> download_timestamp
	- meter_download_timestamp --> event_timestamp
- Removed all echo messages
- Updated log messages
- Replace exit 1 checks with fail()
- Update `README.md`