### PR TITLE
Alora/add lock file

### DIFF
--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -1,26 +1,32 @@
 #!/bin/bash
 
+### HEADER ###
 current_dir=$(dirname "$(readlink -f "$0")")
 # Source the commons.sh file
 source "$current_dir/commons.sh"
 
-# Lock file path
-lock_file="$current_dir/myscript.lock"
+LOCKFILE="/var/lock/`basename $0`" # Define the lock file path using scripts basename
+LOCKFD=99 # Assign a high file descriptor number for locking 
 
-# Check for existing lock file
-if [ -f "$lock_file" ]; then
-    echo "Another instance of the script is running. Exiting."
-    exit 1
-fi
+# PRIVATE
+_lock()             { flock -$1 $LOCKFD; } # Lock function: apply flock with given arg to LOCKFD
+_no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; } # Cleanup function: unlock, remove lockfile
+_prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; } # Ensure lock cleanup runs on script exit
 
-# Create lock file
-touch "$lock_file"
+# ON START
+_prepare_locking 
 
-# Set up trap to remove lock file on script exit
-trap 'rm -f "$lock_file"' EXIT INT TERM
+# PUBLIC
+exlock_now()        { _lock xn; }  # obtain an exclusive lock immediately or fail
+exlock()            { _lock x; }   # obtain an exclusive lock
+shlock()            { _lock s; }   # obtain a shared lock
+unlock()            { _lock u; }   # drop a lock
 
-# Set up trap for SIGINT
-trap "fail 'Operation interupted by SIGINT'" SIGINT
+### BEGINING OF SCRIPT ###
+ 
+# Try to lock exclusively without waiting; exit if another instance is running
+exlock_now || exit 1
+
 
 config_path=""
 download_dir="" # To be potentially overriden by flags

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -12,6 +12,7 @@ LOCKFD=99 # Assign a high file descriptor number for locking
 _lock()             { flock -$1 $LOCKFD; } # Lock function: apply flock with given arg to LOCKFD
 _no_more_locking()  { _lock u; _lock xn && rm -f $LOCKFILE; } # Cleanup function: unlock, remove lockfile
 _prepare_locking()  { eval "exec $LOCKFD>\"$LOCKFILE\""; trap _no_more_locking EXIT; } # Ensure lock cleanup runs on script exit
+_failed_locking()   { echo "Another instance is already running!"; exit 1; } # Error message for failed locking
 
 # ON START
 _prepare_locking 
@@ -25,7 +26,7 @@ unlock()            { _lock u; }   # drop a lock
 ### BEGINING OF SCRIPT ###
  
 # Try to lock exclusively without waiting; exit if another instance is running
-exlock_now || exit 1
+exlock_now || _failed_locking
 
 
 config_path=""

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -4,6 +4,21 @@ current_dir=$(dirname "$(readlink -f "$0")")
 # Source the commons.sh file
 source "$current_dir/commons.sh"
 
+# Lock file path
+lock_file="$current_dir/myscript.lock"
+
+# Check for existing lock file
+if [ -f "$lock_file" ]; then
+    echo "Another instance of the script is running. Exiting."
+    exit 1
+fi
+
+# Create lock file
+touch "$lock_file"
+
+# Set up trap to remove lock file on script exit
+trap 'rm -f "$lock_file"' EXIT INT TERM
+
 # Set up trap for SIGINT
 trap "fail 'Operation interupted by SIGINT'" SIGINT
 


### PR DESCRIPTION
This PR is responsible for adding a locking system to ensure that only one instance of the meter fetch program runs at any time. It uses flock and a dedicated file descriptor (LOCKFD=99) to manage exclusive access to the program resources. 

The implementation:
- Uses file locking with flock to control process concurrency.
- Assigns a high file descriptor number specifically for locking to avoid conflicts with other file operations.
- Ensures the lock is properly released on all possible script exits, including standard completion, interruptions (like CTRL+C), and errors.

I added comments here to explain in more detail. 

```
LOCKFILE="/var/lock/`basename $0`"           # Define the lock file path using script's basename (data_pipeline.sh)
LOCKFD=99                                    # Assign a high file descriptor number for locking

# PRIVATE
_lock()             { flock -$1 $LOCKFD; }   # Lock function: apply flock with given argument to LOCKFD
_no_more_locking()  {                        # Cleanup function: unlock and potentially remove the lock file
  _lock u                                    # Unlock the file descriptor
  _lock xn && rm -f $LOCKFILE                # Try to lock it exclusively without blocking; if succeeds, remove lock file
}
_prepare_locking()  {                        # Set up locking mechanism
  eval "exec $LOCKFD>\"$LOCKFILE\"";         # Open lock file for writing and assign to LOCKFD
  trap _no_more_locking EXIT;                # Ensure lock cleanup runs on script exit
}
_failed_locking()   { echo "Another instance is already running!"; exit 1; } # Error message for failed locking


# ON START
_prepare_locking                             # Initialize locking setup

# PUBLIC
exlock_now()        { _lock xn; }            # Public function: obtain an exclusive lock immediately or fail
exlock()            { _lock x; }             # Public function: obtain an exclusive lock, blocking until available
shlock()            { _lock s; }             # Public function: obtain a shared lock
unlock()            { _lock u; }             # Public function: release the lock

### BEGINNING OF SCRIPT ###
 
exlock_now || _failed_locked()                 # Try to lock exclusively without waiting; exit if another instance is running


```