### PR TITLE
Alora/clean logs

### DIFF
--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -126,9 +126,8 @@ for ((i = 0; i < num_meters; i++)); do
     if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit"; then
         log "Download complete for meter: $meter_id"
     else
-        log "Download failed for meter: $meter_id. Moving to next meter."
+        log "Download failed for meter: $meter_id. Check the logs for details."
         echo "" # Add a newline readability
-        # Skip to the next iteration of the loop
-        continue
     fi
+    
 done

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -126,7 +126,7 @@ for ((i = 0; i < num_meters; i++)); do
     if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit"; then
         log "Download complete for meter: $meter_id"
     else
-        log "Download failed for meter: $meter_id. Check the logs for details."
+        log "Download failed for meter: $meter_id. Move to next meter. Check the logs for details."
         echo "" # Add a newline readability
     fi
     

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -99,7 +99,7 @@ echo "$events_list" | while IFS=, read -r event_id date_dir event_timestamp; do
       loop_success=false
     fi
   else
-    log "Not all files downloaded for event: $event_id"
+    log "Download failed for event_id: $event_id, skipping metadata creation."
     loop_success=false
   fi
 done

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -18,6 +18,7 @@
 # Check if the correct number of arguments are passed
 if [ "$#" -ne 3 ]; then
     fail "Usage: $0 <meter_ip> <meter_id> <output_dir>"
+    exit 1
 fi
 
 meter_ip=$1
@@ -49,6 +50,7 @@ if [ $? -eq 0 ]; then
     log "lftp session successful for: $(basename "$0")"
 else
     fail "lftp session failed for: $(basename "$0")"
+    exit 1
 fi
 
 # Path to CHISTORY.TXT in the temporary directory
@@ -57,6 +59,7 @@ temp_file_path="$temp_dir/$remote_filename"
 # Check if CHISTORY.TXT exists and is not empty
 if [ ! -f "$temp_file_path" ] || [ ! -s "$temp_file_path" ]; then
     fail "Download failed: $remote_filename. Could not find file: $temp_file_path"
+    exit 1
 fi
 
 # Initialize a flag to indicate the success of the entire loop process
@@ -97,7 +100,6 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r line; do
     else
         fail "Skipping line: $line, not entirely numeric. Check parsing."
         loop_success=false
-
     fi
 
 done

--- a/cli_meter/meters/sel735/test_meter_connection.sh
+++ b/cli_meter/meters/sel735/test_meter_connection.sh
@@ -20,7 +20,7 @@ if [ "$#" -ne 2 ]; then
 fi
 
 # Logging in to the FTP server and checking the connection using lftp
-lftp_output=$(lftp -u $USERNAME,$PASSWORD -e "set net:limit-rate $bandwidth_limit; pwd; bye" $meter_ip)
+lftp_output=$(lftp -u $USERNAME,$PASSWORD -e "set net:limit-rate $bandwidth_limit; ls; bye" $meter_ip)
 
 if [ "$?" -eq 0 ]; then
     log "Successful connection test to meter: $meter_ip"


### PR DESCRIPTION
I added exit 1 whenever there was a fail to fix the bug when the meter connection failed. I don't know if you want to keep the logs this way or the exit 1 or 2. You may refactor and do that completely differently. The main fix was in test_meter_connection.sh on line 23

`lftp_output=$(lftp -u $USERNAME,$PASSWORD -e "set net:limit-rate $bandwidth_limit; ls; bye" $meter_ip)`

changed it to ls from pwd


More testing would need to be done to see if that change was the only change that fixed the bugs. 