### PR TITLE
Remove -d/--download_dir flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,6 @@ To run the data pipeline and then transfer data to the Data Acquisition System (
     ./data_pipeline.sh -c /path/to/config.yml
     ```
 
-    ### Optional Flag 
-    Optionally, you can use the `-d/--download_dir` flag to override the download directory from the config file.
-
-    ```bash
-    ./data_pipeline.sh -c /path/to/config.yml -d /path/to/download/dir/
-    ```
-
 2. **Run the Archive Pipeline**
 
     After the `data_pipeline` script completes, execute the `archive_pipeline` script from the `cli_meter` directory. The script requires a configuration file specified via the `-c/--config` flag.
@@ -109,6 +102,6 @@ When you need to stop the pipeline:
 
 - **To Stop Safely/Pause Download**: 
   - Use `Ctrl+C` to interrupt the process. 
-  - If you would like to resume the download, rerun the `data_pipeline`command.The download will resume from where it left off, provided the same config file (`-c`)and download path (`-d`) are used.
+  - If you would like to resume the download, rerun the `data_pipeline`command.The download will resume from where it left off, provided the same config file (`-c`)is used.
 - **Avoid Using `Ctrl+Z`**: 
   - **Do not** use `Ctrl+Z` to suspend the process, as it may cause the pipeline to end without properly closing the FTP connection.

--- a/cli_meter/archive_pipeline.sh
+++ b/cli_meter/archive_pipeline.sh
@@ -27,34 +27,8 @@ _prepare_locking
 # Try to lock exclusively without waiting; exit if another instance is running
 exlock_now || _failed_locking
 
-# Initialize config path variable
-config_path=""
-
-# Check if no command line arguments were provided
-if [ "$#" -eq 0 ]; then
-    show_help_flag
-fi
-
-# Parse command line arguments
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-    -c | --config)
-        if [ -z "$2" ] || [[ "$2" =~ ^- ]]; then
-            log "Error: Missing value for the configuration path after '$1'."
-            show_help_flag
-        fi
-        config_path="$2"
-        shift 2
-        ;;
-    -h | --help)
-        show_help_flag
-        ;;
-    *)
-        log "Unknown parameter passed: $1"
-        show_help_flag
-        ;;
-    esac
-done
+# Parse the config path argument
+config_path=$(parse_config_arg "$@")
 
 # Make sure a config path was set
 if [[ -z "$config_path" ]]; then

--- a/cli_meter/commons.sh
+++ b/cli_meter/commons.sh
@@ -51,32 +51,41 @@ log() {
   echo "$1" >&2
 }
 
+parse_config_arg() {
+  local config_path=""
+
+  # Parse command line arguments for --config/-c flags
+  while [[ "$#" -gt 0 ]]; do
+    case $1 in
+      -c | --config)
+        if [ -z "$2" ] || [[ "$2" =~ ^- ]]; then
+          show_help_flag
+        fi
+        config_path="$2"
+        shift 2
+        ;;
+      -h | --help)
+        show_help_flag
+        ;;
+      *)
+        log "Unknown parameter passed: $1"
+        show_help_flag
+        ;;
+    esac
+  done
+  echo "$config_path"
+}
+
 show_help_flag() {
-  download_flag=false
-
-  if [[ "$1" == "-d" ]]; then
-    download_flag=true
-  fi
-
   log "Usage: $0 [options]"
   log ""
   log "Options:"
   log "  -c, --config <path>          Specify the path to the YML config file."
-  if [[ "$download_flag" == true ]]; then
-    log "  -d, --download_dir <path>    Specify the path to the download directory."
-  fi
   log "  -h, --help                   Display this help message and exit."
   log ""
   log "Examples:"
-  if [[ "$download_flag" == true ]]; then
-    log "  $0 -c /path/to/config.yml -d /path/to/download_dir"
-    log "  $0 --config /path/to/config.yml --download_dir /path/to/download_dir"
-  else
-    log "  $0 -c /path/to/config.yml"
-    log "  $0 --config /path/to/config.yml"
-  fi
-  exit 0
-
+  log "  $0 -c /path/to/config.yml"
+  log "  $0 --config /path/to/config.yml"
 }
 
 # Export functions for use in other scripts

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -30,41 +30,8 @@ _prepare_locking
 # Try to lock exclusively without waiting; exit if another instance is running
 exlock_now || _failed_locking
 
-# To be optionally be overriden by flags
-config_path=""
-download_dir=""
-
-# Check if no command line arguments were provided
-if [ "$#" -eq 0 ]; then
-    show_help_flag "-d"
-fi
-
-# Parse command line arguments for --config/-c and --download_dir/-d flags
-while [[ "$#" -gt 0 ]]; do
-    case $1 in
-    -c | --config)
-        if [ -z "$2" ] || [[ "$2" =~ ^- ]]; then
-            show_help_flag "-d"
-        fi
-        config_path="$2"
-        shift 2
-        ;;
-    -d | --download_dir)
-        if [ -z "$2" ] || [[ "$2" =~ ^- ]]; then
-            show_help_flag "-d"
-        fi
-        download_dir="$2"
-        shift 2
-        ;;
-    -h | --help)
-        show_help_flag "-d"
-        ;;
-    *)
-        log "Unknown parameter passed: $1"
-        show_help_flag "-d"
-        ;;
-    esac
-done
+# Parse the config path argument
+config_path=$(parse_config_arg "$@")
 
 # Make sure the output config file exists
 if [ -f "$config_path" ]; then


### PR DESCRIPTION
This PR:
- Removes functionality for the `-d/--download_dir` flag 
- Adds function in `commons.sh` for parse the `-c/--config` flag
- Updates Readme