### PR TITLE
Fix inifite loop in -c flag

### DIFF
--- a/cli_meter/archive_pipeline.sh
+++ b/cli_meter/archive_pipeline.sh
@@ -28,20 +28,10 @@ _prepare_locking
 exlock_now || _failed_locking
 
 # Parse the config path argument
-config_path=$(parse_config_arg "$@")
+config_path=$(parse_config_arg "$@") || exit 1
 
-# Make sure a config path was set
-if [[ -z "$config_path" ]]; then
-    log "Config path must be specified."
-    show_help_flag
-fi
-
-# Make sure the config file exists
-if [ -f "$config_path" ]; then
-    log "Config file exists at: $config_path"
-else
-    fail "Config: Config file does not exist."
-fi
+# Make sure the output config file exists
+[ -f "$config_path" ] && log "Config file exists at: $config_path" || fail "Config: Config file does not exist."
 
 # Parse general configuration using yq
 bwlimit=$(yq e '.bandwidth_limit // "0"' "$config_path")

--- a/cli_meter/commons.sh
+++ b/cli_meter/commons.sh
@@ -60,19 +60,24 @@ parse_config_arg() {
       -c | --config)
         if [ -z "$2" ] || [[ "$2" =~ ^- ]]; then
           show_help_flag
+          fail "Config path not provided or invalid after -c/--config"
         fi
         config_path="$2"
         shift 2
         ;;
       -h | --help)
         show_help_flag
+        exit 1
         ;;
       *)
-        log "Unknown parameter passed: $1"
         show_help_flag
+        fail "Unknown parameter: $1"
         ;;
     esac
   done
+
+  [ -z "$config_path" ] && { show_help_flag; fail "Config path is required but not provided"; }
+
   echo "$config_path"
 }
 
@@ -87,6 +92,7 @@ show_help_flag() {
   log "  $0 -c /path/to/config.yml"
   log "  $0 --config /path/to/config.yml"
 }
+
 
 # Export functions for use in other scripts
 export -f log


### PR DESCRIPTION
Made some code more concise by using && and || operators and refactored the parse_config_arg function to return the proper error messages.