### PR TITLE
Add max days for downloading

### DIFF
--- a/cli_meter/config/config.yml.example
+++ b/cli_meter/config/config.yml.example
@@ -14,8 +14,12 @@ download_directory: ""
 # Configuration settings
 location: ""    # Geographic location of the data collection
 data_type: ""   # Type of data being collected
+
 # bytes/s, 0 means unlimited, Suffixes are supported, e.g. 100K means 102400.
 bandwidth_limit: "0"
+
+# Download data within x of days
+max_age_days: 
 
 # Default FTP credentials (overridden by meter-specific credentials)
 credentials:

--- a/cli_meter/config/config.yml.example
+++ b/cli_meter/config/config.yml.example
@@ -18,7 +18,7 @@ data_type: ""   # Type of data being collected
 # bytes/s, 0 means unlimited, Suffixes are supported, e.g. 100K means 102400.
 bandwidth_limit: "0"
 
-# Download data within x of days
+# Optional, leave empty to download all available
 max_age_days: 
 
 # Default FTP credentials (overridden by meter-specific credentials)

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -51,7 +51,10 @@ max_age_days=$(yq '.max_age_days' "$config_path")
 [[ -z "$data_type" || "$data_type" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Data type cannot be null or empty."
 [[ -z "$bandwidth_limit" || "$bandwidth_limit" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Bandwidth limit cannot be null or empty."
 [[ -z "$num_meters" || "$num_meters" -eq 0 ]] && failure $STREAMS_INVALID_CONFIG "Must have at least 1 meter in the config file."
-[[ -z "$max_age_days" || "$max_age_days" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Max age days cannot be null or empty."  # New validation for max_age_days
+# if max_age_days is set make sure max_age_days is a number
+if [[ ! -z "$max_age_days" && "$max_age_days" != "null" ]]; then
+    [[ ! "$max_age_days" =~ ^[1-9]+$ ]] && failure $STREAMS_INVALID_CONFIG "Max age days must be an integer greater than 0: '$max_age_days' "
+fi
 
 # Create the base output directory
 output_dir="$download_dir/$location/$data_type"

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -41,6 +41,7 @@ num_meters=$(yq '.meters | length' "$config_path")
 location=$(yq '.location' "$config_path")
 data_type=$(yq '.data_type' "$config_path")
 bandwidth_limit=$(yq '.bandwidth_limit' "$config_path")
+max_age_days=$(yq '.max_age_days' "$config_path")
 
 # Check for null or empty values
 [[ -z "$download_dir" || "$download_dir" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Download directory cannot be null or empty."
@@ -50,6 +51,7 @@ bandwidth_limit=$(yq '.bandwidth_limit' "$config_path")
 [[ -z "$data_type" || "$data_type" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Data type cannot be null or empty."
 [[ -z "$bandwidth_limit" || "$bandwidth_limit" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Bandwidth limit cannot be null or empty."
 [[ -z "$num_meters" || "$num_meters" -eq 0 ]] && failure $STREAMS_INVALID_CONFIG "Must have at least 1 meter in the config file."
+[[ -z "$max_age_days" || "$max_age_days" == "null" ]] && failure $STREAMS_INVALID_CONFIG "Max age days cannot be null or empty."  # New validation for max_age_days
 
 # Create the base output directory
 output_dir="$download_dir/$location/$data_type"
@@ -70,7 +72,7 @@ for ((i = 0; i < num_meters; i++)); do
     export PASSWORD=${meter_password:-$default_password}
 
     # Execute download script and check its success in one step
-    if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit" "$data_type" "$location"; then
+    if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit" "$data_type" "$location" "$max_age_days" ; then
         log "Download complete for meter: $meter_id"
     else
         warning "Download incomplete for meter: $meter_id"

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -105,7 +105,7 @@ validate_complete_directory() {
     # Check for metadata files
     local metadata_files=("${event_id}_metadata.yml" "checksum.md5")
     for file in "${metadata_files[@]}"; do
-        log "Checking for metadata file: ${file} in directory: ${event_dir}"
+        log "Checking for metadata file: ${file}"
         if [ ! -f "${event_dir}/${file}" ]; then
             log "Missing metadata file: ${file} in directory: ${event_dir}"
             mark_event_incomplete "$event_id" "$(dirname "$event_dir")" && return 1 # False - Metadata file is missing

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -114,3 +114,20 @@ validate_complete_directory() {
 
     return 0 # True - All files are present
 }
+
+# Function to generate date directory name
+generate_date_dir() {
+    local year=$1
+    local month=$2
+    
+    formatted_month=$(printf '%02d' "$month")
+    date_dir="$year-$formatted_month"
+    echo "$date_dir"
+}
+
+# Function to calculate the max allowable date
+calculate_max_date() {
+    local max_age_days=$1
+    max_date=$(date -d "$max_age_days days ago" '+%Y-%m-%d')
+    echo "$max_date"
+}

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -30,7 +30,7 @@ trap 'handle_sig SIGQUIT' SIGQUIT
 trap 'handle_sig SIGTERM' SIGTERM
 
 # Check for exactly 7 arguments
-[ "$#" -ne 7 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> <output_dir> <meter_id> <meter_type> <bw_limit> <data_type> <location>"
+[ "$#" -ne 8 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> <output_dir> <meter_id> <meter_type> <bw_limit> <data_type> <location> <max_age_days>"
 
 # Simple CLI flag parsing
 meter_ip="$1"
@@ -41,7 +41,8 @@ meter_type="$4"
 bandwidth_limit="$5"
 data_type="$6"
 location="$7"
-
+max_age_days="$8"
+log "Max age days: $max_age_days"
 log "Starting download process for meter: $meter_id"
 
 # Make dir if it doesn't exist
@@ -51,7 +52,7 @@ mkdir -p "$base_output_dir"
 source "$current_dir/test_meter_connection.sh" "$meter_ip" "$bandwidth_limit"
 
 # output_dir is the location where the data will be stored
-for event_info in $("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir"); do
+for event_info in $("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir" "$max_age_days"); do
 
   # Split the output into variables
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -20,25 +20,6 @@
 #                     common_utils.sh
 #                     $USERNAME and $PASSWORD environment variables
 # ==============================================================================
-# Function to generate date directory name
-generate_date_dir() {
-    local year=$1
-    local month=$2
-    local base_output_dir=$3
-
-    formatted_month=$(printf '%02d' "$month")
-    date_dir="$year-$formatted_month"
-    echo "$date_dir"
-}
-
-# Function to calculate the max allowable date
-calculate_max_date() {
-    local max_age_days=$1
-    max_date=$(date -d "$max_age_days days ago" '+%Y-%m-%d')
-    echo "$max_date"
-}
-
-# ==============================================================================
 
 current_dir=$(dirname "$(readlink -f "$0")")
 log "Current directory: $current_dir"

--- a/cli_meter/test/test_commons.bats
+++ b/cli_meter/test/test_commons.bats
@@ -146,3 +146,35 @@ create_metadata_files() {
   assert_failure
   assert_output --partial "Missing file: HR_${EVENT_ID}.ZDAT in directory: $EVENT_DIR"
 }
+
+@test "generate_date_dir function returns the correct date directory" {
+  run generate_date_dir 2021 10
+  assert_success
+  assert_output "2021-10"
+}
+
+@test "generate_date_dir function returns the correct date directory with leading zero" {
+  run generate_date_dir 2021 01
+  assert_success
+  assert_output "2021-01"
+}
+
+@test "calculate_max_date function returns the correct date" {
+  run calculate_max_date 5
+  assert_success
+  assert_output "$(date -d "5 days ago" +%Y-%m-%d)"
+}
+
+@test "calculate_max_date function returns the correct date for 1 day" {
+  run calculate_max_date 1
+  assert_success
+  assert_output "$(date -d "1 days ago" +%Y-%m-%d)"
+}
+
+@test "calculate_max_date function returns the correct date for 10 days" {
+  run calculate_max_date 10
+  assert_success
+  assert_output "$(date -d "10 days ago" +%Y-%m-%d)"
+}
+
+


### PR DESCRIPTION
This PR:
- adds `max_age_days` to `config.yml` to only download events within that many days
- this is optional, if left empty will download all available
- adds a `calculate_max_date()` function in `common_sel735`
- moved `generate_date_dir()` to `common_sel735`