### PR TITLE
Update regex for max_age_days

### DIFF
--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -53,7 +53,7 @@ max_age_days=$(yq '.max_age_days' "$config_path")
 [[ -z "$num_meters" || "$num_meters" -eq 0 ]] && failure $STREAMS_INVALID_CONFIG "Must have at least 1 meter in the config file."
 # if max_age_days is set make sure max_age_days is a number
 if [[ ! -z "$max_age_days" && "$max_age_days" != "null" ]]; then
-    [[ ! "$max_age_days" =~ ^[1-9]+$ ]] && failure $STREAMS_INVALID_CONFIG "Max age days must be an integer greater than 0: '$max_age_days' "
+    [[ ! "$max_age_days" =~ ^[1-9][0-9]*$ ]] && failure $STREAMS_INVALID_CONFIG "Max age days must be an integer greater than 0: '$max_age_days' "
 fi
 
 # Create the base output directory


### PR DESCRIPTION
This PR:
- fixes the regex in `data_pipeline.sh` that validates `max_age_date` in the config file to allow for digits ending in 0.