### PR TITLE
Cleanup Working Dir

### DIFF
--- a/cli_meter/meters/sel735/cleanup_incomplete.sh
+++ b/cli_meter/meters/sel735/cleanup_incomplete.sh
@@ -23,16 +23,11 @@ base_directory="$1"
 # Check if base_directory exists
 [ -d "$base_directory" ] && log "Base directory exists" || failure $STREAMS_DIR_NOT_FOUND "Base directory does not exist."
 
-log "Starting cleanup process in directory: $base_directory"
+log "Cleaning up any incomplete directories in directory: $base_directory"
 
 # Find and delete all directories matching the pattern *.incomplete_<digit>
 find "$base_directory" -type d -regex '.*/.*\.incomplete_[0-9]+' -print0 | while IFS= read -r -d '' dir; do
   rm -rf "$dir" && log "Successfully deleted directory: $dir" || log "Failed to delete directory: $dir"
-done
-
-# Find and delete all empty directories
-find "$base_directory" -type d -empty -print0 | while IFS= read -r -d '' dir; do
-  rmdir "$dir" && log "Successfully deleted empty directory: $dir" || log "Failed to delete empty directory: $dir"
 done
 
 log "Cleanup process completed in directory: $base_directory"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -51,8 +51,17 @@ mkdir -p "$base_output_dir"
 # Test connection to meter
 source "$current_dir/test_meter_connection.sh" "$meter_ip" "$bandwidth_limit"
 
+# Capture the output of get_events.sh
+events=$("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir" "$max_age_days")
+
+# Check if events is empty
+if [ -z "$events" ]; then
+  log "No new events to download for meter: $meter_id"
+  exit 0
+fi
+
 # output_dir is the location where the data will be stored
-for event_info in $("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir" "$max_age_days"); do
+for event_info in $events; do
 
   # Split the output into variables
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -88,7 +88,7 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r event_line; do
 
         # If the event directory does not exist, print the event ID else validate the directory
         if [ ! -d "$event_dir_path" ]; then
-            log "No directory found, proceeding to download event: $event_id"
+            log "Proceeding to download event: $event_id"
             echo "$event_id,$date_dir,$event_timestamp"
         fi
     else

--- a/cli_meter/meters/sel735/get_events.sh
+++ b/cli_meter/meters/sel735/get_events.sh
@@ -90,11 +90,6 @@ awk 'NR > 3' "$temp_file_path" | while IFS= read -r event_line; do
         if [ ! -d "$event_dir_path" ]; then
             log "No directory found, proceeding to download event: $event_id"
             echo "$event_id,$date_dir,$event_timestamp"
-        else
-            validate_complete_directory "$event_dir_path" "$event_id" && log "Complete directory for event: $event_id" || {
-                log "Incomplete directory, proceeding to download event: $event_id"
-                echo "$event_id,$date_dir,$event_timestamp"
-            }
         fi
     else
         log "Event $event_id is older than date range, skipping."

--- a/cli_meter/meters/sel735/zip_event.sh
+++ b/cli_meter/meters/sel735/zip_event.sh
@@ -2,15 +2,18 @@
 # ==============================================================================
 # Script Name:        zip_event.sh
 # Description:        This script zips the event files in the source directory
-#                     and saves the zip file in the destination directory.
+#                     and saves the zip file in the destination directory and removes
+#                     the files in the source directory, but leaves the directory to
+#                     be used to compare with the history file.
 #
-# Usage:              ./zip_event.sh <source_dir> <dest_dir> <event_id>
+# Usage:              ./zip_event.sh <source_dir> <dest_dir> <event_id> <zip_filename>
 # Called by:          download.sh
 #
 # Arguments:
 #   source_dir        The directory containing the event files
 #   dest_dir          The directory where the zip file will be saved
 #   event_id          The event ID (ex.10000)
+#   zip_filename      The name of the zip file (ex. location-dataType-meterId-YYYYMM-eventId.zip)
 #
 # Requirements:       zip
 #                     common_utils.sh
@@ -19,7 +22,7 @@ current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh"
 
-# Check for exactly 3 arguments
+# Check for exactly 4 arguments
 [ "$#" -ne 4 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <source_dir> <dest_dir> <event_id> <zip_filename>"
 
 source_dir="$1"
@@ -33,3 +36,6 @@ zip_filename="$4"
 pushd "$source_dir" > /dev/null
 zip -r -q "${dest_dir}/${zip_filename}" $event_id && log "Zipped files for event: $event_id" || failure $STREAMS_ZIP_FAIL "Failed to zip event: $event_id in directory: $source_dir"
 popd > /dev/null
+
+# Delete the files in the event_id directory but not the directory itself
+find "$source_dir/$event_id" -type f -delete && log "Deleted files in event directory: $source_dir/$event_id" || failure $STREAMS_UNKNOWN "Failed to delete files in event directory: $source_dir/$event_id"


### PR DESCRIPTION
This PR:
- Removes files from event directory in `working` after successfully being zipped.
- Updates `cleanup_incomplete.sh` to remove cleaning up empty directories.
  - We still need these directories for comparing the `CHISTORY` file

- Adds a check to see if `get_events.sh` returns an empty list, if so exit (no new downloads)