### PR TITLE
Add timeout/max-retries to LFTP test connection

### DIFF
--- a/cli_meter/config/config.yml.example
+++ b/cli_meter/config/config.yml.example
@@ -1,37 +1,40 @@
-# ==============================================================================
-# Configuration File for SEL735 Event Data Collection
-# Contains settings for application, download location, credentials, and meters.
-# ==============================================================================
+# This file contains the configuration settings for SEL735 meters.
 
 # General settings for the application
 application:
   name: "Event Data Collection"
-  version: ""  # Version number of the application
+  version: 2.0
 
-# Default download directory (overridden by -d/--download_dir flag if specified)
+# Configuration Settings
+location: ""
+data_type: ""
 download_directory: ""
 
-# Configuration settings
-location: ""    # Geographic location of the data collection
-data_type: ""   # Type of data being collected
-
 # bytes/s, 0 means unlimited, Suffixes are supported, e.g. 100K means 102400.
-bandwidth_limit: "0"
-
-# Optional, leave empty to download all available
+bandwidth_limit: 0
+# If empty, the default to 1.
+max_conection_retries: 
 max_age_days: 
 
-# Default FTP credentials (overridden by meter-specific credentials)
+# Require default credentials for FTP server
 credentials:
-  username: ""  # Default FTP username
-  password: ""  # Default FTP password
+  username: ""
+  password: ""
 
-# Meter configurations with optional username/password overrides
+# Configuration for the meter and optional username/password override
 meters:
-  # Meter 1
-  - ip: ""       # IP address of the meter
-    id: ""       # Unique identifier for the meter
-    type: ""     # Type of the meter (e.g., "SEL735")
+# Meter 1
+  - ip: ""
+    id: ""
+    type: ""
     credentials:
-      username: ""  # Optional FTP username override for this meter
-      password: ""  # Optional FTP password override for this meter
+      username: "" # Optional override
+      password: "" # Optional override
+# Meter 2
+  - ip: ""
+    id: ""
+    type: ""
+    credentials:
+      username: "" # Optional override
+      password: "" # Optional override
+

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 # ==============================================================================
 # Script Name:        common_sel735.sh
-# Description:        Common utility functions for SEL-735 scripts in Meter Event Data Pipeline.
+# Description:        Common utility functions for SEL-735 scripts in the Meter Event Data Pipeline.
 #
 # Functions:
 #   handle_sig                  - Handles signals and marks the current event as incomplete
 #   mark_event_incomplete       - Marks an event as incomplete and rotates older incomplete directories
 #   validate_download           - Validates if all files for an event have been downloaded
 #   validate_complete_directory - Validates if the directory is complete
+#   generate_date_dir           - Generates a formatted date directory name
+#   calculate_max_date          - Calculates the maximum allowable date based on the specified age in days
 #
 # ==============================================================================
 current_dir=$(dirname "$(readlink -f "$0")")
@@ -76,7 +78,7 @@ mark_event_incomplete() {
     log "" # Add a new line for better readability
     log "Moved event $event_id to ${event_id}.incomplete_${suffix}"
   else
-    log "[ERROR] Directory $original_dir does not exist."
+    warning "Directory $original_dir does not exist."
   fi
 }
 

--- a/cli_meter/meters/sel735/create_message.sh
+++ b/cli_meter/meters/sel735/create_message.sh
@@ -7,7 +7,7 @@
 #                     <data_type> <output_dir>
 #
 # Arguments:
-#   event_id                ID
+#   event_id          event ID
 #   zip_filename      Name of the zipped file
 #   path              Path to file
 #   data_type         Type of data

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -29,8 +29,8 @@ trap 'handle_sig SIGINT' SIGINT
 trap 'handle_sig SIGQUIT' SIGQUIT
 trap 'handle_sig SIGTERM' SIGTERM
 
-# Check for exactly 7 arguments
-[ "$#" -ne 8 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> <output_dir> <meter_id> <meter_type> <bw_limit> <data_type> <location> <max_age_days>"
+# Check for exactly 9 arguments
+[ "$#" -ne 9 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> <output_dir> <meter_id> <meter_type> <bw_limit> <data_type> <location> <max_age_days> <max_retries>"
 
 # Simple CLI flag parsing
 meter_ip="$1"
@@ -42,14 +42,15 @@ bandwidth_limit="$5"
 data_type="$6"
 location="$7"
 max_age_days="$8"
-log "Max age days: $max_age_days"
+max_retries="$9"
+
 log "Starting download process for meter: $meter_id"
 
 # Make dir if it doesn't exist
 mkdir -p "$base_output_dir"
 
 # Test connection to meter
-source "$current_dir/test_meter_connection.sh" "$meter_ip" "$bandwidth_limit"
+source "$current_dir/test_meter_connection.sh" "$meter_ip" "$bandwidth_limit" "$max_retries" || failure $STREAMS_CONNECTION_FAIL "Failed to connect to meter"
 
 # Capture the output of get_events.sh
 events=$("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir" "$max_age_days")

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -6,7 +6,7 @@
 #                     metadata, and zipping the files.
 #
 # Usage:              ./download.sh <meter_ip> <output_dir> <meter_id> <meter_type>
-#                     <bandwidth_limit> <data_type> <location>
+#                     <bandwidth_limit> <data_type> <location> <max_age_days> <max_retries>
 # Called by:          data_pipeline.sh
 #
 # Arguments:
@@ -14,9 +14,15 @@
 #   output_dir        Base directory where the event data will be stored
 #   meter_id          Meter ID
 #   meter_type        Meter Type (ex. sel735)
+#   bandwidth_limit   Bandwidth limit for the connection
+#   data_type         Data type (ex. power)
+#   location          Location of the meter
+#   max_age_days      Maximum age of the event in days
+#   max_retries       Maximum number of retries for the connection
 #
 # Requirements:       common_sel735.sh, test_meter_connection.sh, get_events.sh,
 #                     download_event.sh, generate_event_metadata.sh, zip_event.sh
+#                     create_message.sh
 # ==============================================================================
 current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
@@ -63,10 +69,9 @@ fi
 
 # output_dir is the location where the data will be stored
 for event_info in $events; do
-
-  # Split the output into variables
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"
   log "Processing event: $event_id"
+
   # Update current_event_id for mark_event_incomplete
   current_event_id=$event_id
 
@@ -84,18 +89,20 @@ for event_info in $events; do
 
   download_end=$(date -u --iso-8601=seconds)
   
+  # Validate the downloaded files
   validate_download "$output_dir/$event_id" "$event_id" && log "Downloaded files validated for event: $event_id" || {
     log "Not all files downloaded for event: $event_id"
     mark_event_incomplete "$event_id" "$output_dir"
     continue
   }
 
-  # Execute generate_metadata_yml.sh
+  # Generate metadata for the event
   "$current_dir/generate_metadata_yml.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_start" "$download_end" || {
     mark_event_incomplete
     failure $STREAMS_METADATA_FAIL "Failed to generate metadata"
   }
 
+  # Validate the metadata files
   validate_complete_directory "$output_dir/$event_id" "$event_id" && log "Metadata files validated for event: $event_id" || {
     mark_event_incomplete
     failure $STREAMS_INCOMPLETE_DIR "Missing metadata file in event directory"
@@ -109,13 +116,13 @@ for event_info in $events; do
   zip_filedate="${date_dir//-/}"
   zip_filename="$location-$data_type-$meter_id-$zip_filedate-$event_id.zip"
 
-  # Execute zip_event.sh
+  # Zip the event files and empty the working event directory
   "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$zip_filename"|| {
     mark_event_incomplete
     failure $STREAMS_ZIP_FAIL "Failed to zip event files"
   }
 
-  # Execute create_message.sh
+  # Create the message file (JSON) for the event
   "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$path" "$data_type" "$event_zipped_output_dir" || {
     mark_event_incomplete
     warning $STREAMS_FILE_CREATION_FAIL "Failed to create message file"

--- a/cli_meter/meters/sel735/download_event.sh
+++ b/cli_meter/meters/sel735/download_event.sh
@@ -19,10 +19,9 @@ current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh"
 
-# Check if the correct number of arguments are passed
+# Check if at least 3 arguments are passed
 [ "$#" -lt 3 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> <event_id> <output_dir> [bandwidth_limit]"
 
-# Extracting arguments into variables
 meter_ip=$1
 event_id=$2
 download_dir="$3/$event_id" # Assumes $3 = /../location/data_type/YYYY-MM/METER_ID/working
@@ -32,7 +31,7 @@ remote_dir="EVENTS"
 # Create the local directory for this event if it doesn't exist
 mkdir -p "$download_dir" && log "Created local directory for event: $event_id" || failure $STREAMS_DIR_CREATION_FAIL "Failed to create local directory for event: $event_id"
 
-# Single lftp session to download the files
+# Single lftp session to download the files containing the event_id
 lftp -u "$USERNAME,$PASSWORD" "$meter_ip" <<END_FTP_SESSION
 set xfer:clobber on
 set net:limit-rate $bandwidth_limit

--- a/cli_meter/meters/sel735/test_meter_connection.sh
+++ b/cli_meter/meters/sel735/test_meter_connection.sh
@@ -4,13 +4,15 @@
 # Description:        This script checks the connection to the meter
 #                     via FTP using provided environment variables.
 #
-# Usage:              ./test_meter_connection.sh <meter_ip>
+# Usage:              ./test_meter_connection.sh <meter_ip> [bandwidth_limit] [max_retries]
 # Called by:          download.sh
 #
 # Arguments:
 #   meter_ip          IP address of the meter
 #   bandwidth_limit   Optional: Bandwidth limit for the connection
-#                     (default is 0)
+#                     (default is 0/unlimited)
+#   max_retries       Optional: Maximum number of retries for the connection
+#                     (default is 1)
 #
 # Requirements:       lftp
 #                     common_utils.sh
@@ -30,13 +32,13 @@ max_retries="${3:-1}"
 reconnect_interval_base=5
 
 # Logging in to the FTP server and checking the connection using lftp
-lftp_output=$(lftp -u $USERNAME,$PASSWORD $meter_ip <<LFTP
+lftp_output=$(lftp -u $USERNAME,$PASSWORD $meter_ip <<END_FTP_SESSION
     set net:max-retries $max_retries;
     set net:reconnect-interval-base $reconnect_interval_base;
     set net:limit-rate $bandwidth_limit;
     ls;
     bye
-LFTP
+END_FTP_SESSION
 )
 
 lftp_exit_code=$?

--- a/cli_meter/meters/sel735/test_meter_connection.sh
+++ b/cli_meter/meters/sel735/test_meter_connection.sh
@@ -20,13 +20,25 @@ script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh"
 
 # Check if at least 1 argument is passed
-[ "$#" -lt 1 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> [bandwidth_limit]"
+[ "$#" -lt 1 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_ip> [bandwidth_limit] [max_retries]"
 
 meter_ip="$1"
-bandwidth_limit="${2:-0}" # If not set default to 0
+bandwidth_limit="${2:-0}"
+max_retries="${3:-1}"
+
+# Set intervals between lftp connection attempts (s)
+reconnect_interval_base=5
 
 # Logging in to the FTP server and checking the connection using lftp
-lftp_output=$(lftp -u $USERNAME,$PASSWORD -e "set net:limit-rate $bandwidth_limit; ls; bye" $meter_ip)
+lftp_output=$(lftp -u $USERNAME,$PASSWORD $meter_ip <<LFTP
+    set net:max-retries $max_retries;
+    set net:reconnect-interval-base $reconnect_interval_base;
+    set net:limit-rate $bandwidth_limit;
+    ls;
+    bye
+LFTP
+)
+
 lftp_exit_code=$?
 
 [ "$lftp_exit_code" -eq 0 ] && log "Successful connection test to meter: $meter_ip"|| failure $STREAMS_LFTP_FAIL "Connection Unsuccessful to meter: $meter_ip"

--- a/cli_meter/test/test_commons.bats
+++ b/cli_meter/test/test_commons.bats
@@ -29,7 +29,7 @@ teardown() {
 @test "mark_event_incomplete function directory doesn't exit" {
   run mark_event_incomplete "$EVENT_ID" "$TMP_DIR/$DATE_DIR"   
   assert_success
-  assert_output --partial "[ERROR] Directory $TMP_DIR/$DATE_DIR/$EVENT_ID does not exist."
+  assert_output --partial "[WARNING] Directory $TMP_DIR/$DATE_DIR/$EVENT_ID does not exist."
 }
 
 @test "mark_event_incomplete function rotate directories" {

--- a/cli_meter/test/test_meter_connection.bats
+++ b/cli_meter/test/test_meter_connection.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+# Use this script to test functions/scripts in /cli_meter directory
+SCRIPT_DIR="meters/sel735"
+setup() {
+    load 'test_helper/common'
+    _common_setup
+    cd $SCRIPT_DIR
+}
+
+teardown() {
+    _common_teardown
+}
+
+@test "test_meter_connection.sh shows usage for no arguments" {
+    run ./test_meter_connection.sh
+    assert_failure
+    assert_output --partial "[ERROR] Usage: test_meter_connection.sh <meter_ip> [bandwidth_limit] [max_retries]. Exit code: $STREAMS_INVALID_ARGS"
+}


### PR DESCRIPTION
This PR:
-  Adds `max_connection_retries` to `config.yml` to set the number of connection attempts to a meter 
  - If not set it defaults to 1
  - `max_retries` in lftp works with `reconnect_interval_base` to set the time (sec) in between retries
  - `reconnect_interval_base` is currently set to `5` in `test_meter_connection.sh`
- `data_pipeline.sh` checks to make sure `max_connection_retries` is between (1-10) (I chose 10 as a max can be changed)