### PR TITLE
Create YML Download Summary

### DIFF
--- a/cli_meter/common_utils.sh
+++ b/cli_meter/common_utils.sh
@@ -71,16 +71,16 @@ unlock()            { _lock u; }   # drop a lock
 # Utility functions
 failure() {
   local exit_code="${1:-$UNKNOWN}"
-  local message="${2:-""}"
+  local message="${2:-"Unknown error"}"
 
   log "[ERROR] $message. Exit code: $exit_code"
   exit $exit_code
 }
 
 warning(){
-  local message="${1:-""}"
-  local exit_code="${2:-$UNKNOWN}"
-  log "[WARNING] $message. Exit code: $exit_code"
+  local code="${1:-$UNKNOWN}"
+  local message="${2:-"Unknown warning"}"
+  log "[WARNING] $message. Exit code: $code"
 }
 
 log() {

--- a/cli_meter/common_utils.sh
+++ b/cli_meter/common_utils.sh
@@ -73,13 +73,14 @@ failure() {
   local exit_code="${1:-$UNKNOWN}"
   local message="${2:-""}"
 
-  log "[ERROR] $message. Exit code: $exit_code"
+  log "[ERROR] $message, exit code: $exit_code"
   exit $exit_code
 }
 
 warning(){
   local message="${1:-""}"
-  log "[WARNING] $message"
+  local exit_code="${2:-$UNKNOWN}"
+  log "[WARNING] $message, code: $exit_code"
 }
 
 log() {

--- a/cli_meter/common_utils.sh
+++ b/cli_meter/common_utils.sh
@@ -73,14 +73,14 @@ failure() {
   local exit_code="${1:-$UNKNOWN}"
   local message="${2:-""}"
 
-  log "[ERROR] $message, exit code: $exit_code"
+  log "[ERROR] $message. Exit code: $exit_code"
   exit $exit_code
 }
 
 warning(){
   local message="${1:-""}"
   local exit_code="${2:-$UNKNOWN}"
-  log "[WARNING] $message, code: $exit_code"
+  log "[WARNING] $message. Exit code: $exit_code"
 }
 
 log() {

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -71,7 +71,8 @@ LOG_DIR="$download_dir/logs"
 mkdir -p "$LOG_DIR"
 YAML_SUMMARY_FILE="$LOG_DIR/download_summary_$TIMESTAMP.yml"
 export YAML_SUMMARY_FILE
-init_summary "$YAML_SUMMARY_FILE"
+download_start_time=$(date -u --iso-8601=seconds)
+init_summary "$YAML_SUMMARY_FILE" "$download_start_time"
 
 # Loop through the meters and download the event files
 for ((i = 0; i < num_meters; i++)); do
@@ -102,7 +103,10 @@ for ((i = 0; i < num_meters; i++)); do
     meter_end_time=$(date -u --iso-8601=seconds)
 
     # Append meter information after processing
-    append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status"  "$meter_end_time"
+    append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status" "$meter_start_time" "$meter_end_time"
 done
+
+download_end_time=$(date -u --iso-8601=seconds)
+append_timestamps "$YAML_SUMMARY_FILE" "$download_start_time" "$download_end_time" "download"
 
 log "All meters have been processed"

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -76,7 +76,6 @@ init_summary "$YAML_SUMMARY_FILE" "$download_start_time" $num_meters
 
 # Loop through the meters and download the event files
 for ((i = 0; i < num_meters; i++)); do
-    increase_meters_attemped "$YAML_SUMMARY_FILE" 
     meter_type=$(yq ".meters[$i].type" $config_path)
     meter_ip=$(yq ".meters[$i].ip" $config_path)
     meter_id=$(yq ".meters[$i].id" $config_path)
@@ -97,20 +96,17 @@ for ((i = 0; i < num_meters; i++)); do
 
     if [ $download_return_code -eq 0 ]; then
         log "Download complete for meter: $meter_id"
-        meter_status="success"
-        increase_meters_successful "$YAML_SUMMARY_FILE"
     else
         error_code=$download_return_code
         error_message="Download failed for meter: $meter_id"
-        meter_status="failure"
         warning "$error_code" "$error_message" 
         append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
         update_skipped "$YAML_SUMMARY_FILE" "$meter_id"
-        increase_meters_failed "$YAML_SUMMARY_FILE"
     fi
 
     # Append meter information after processing
     meter_end_time=$(date -u --iso-8601=seconds)
+    meter_status=$(get_meter_status "$YAML_SUMMARY_FILE" "$meter_id")
     append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status" "$meter_start_time" "$meter_end_time"
 done
 

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -72,10 +72,11 @@ mkdir -p "$LOG_DIR"
 YAML_SUMMARY_FILE="$LOG_DIR/download_summary_$TIMESTAMP.yml"
 export YAML_SUMMARY_FILE
 download_start_time=$(date -u --iso-8601=seconds)
-init_summary "$YAML_SUMMARY_FILE" "$download_start_time"
+init_summary "$YAML_SUMMARY_FILE" "$download_start_time" $num_meters
 
 # Loop through the meters and download the event files
 for ((i = 0; i < num_meters; i++)); do
+    increase_meters_attemped "$YAML_SUMMARY_FILE" 
     meter_type=$(yq ".meters[$i].type" $config_path)
     meter_ip=$(yq ".meters[$i].ip" $config_path)
     meter_id=$(yq ".meters[$i].id" $config_path)
@@ -97,6 +98,7 @@ for ((i = 0; i < num_meters; i++)); do
     if [ $download_return_code -eq 0 ]; then
         log "Download complete for meter: $meter_id"
         meter_status="success"
+        increase_meters_successful "$YAML_SUMMARY_FILE"
     else
         error_code=$download_return_code
         error_message="Download failed for meter: $meter_id"
@@ -104,6 +106,7 @@ for ((i = 0; i < num_meters; i++)); do
         warning "$error_code" "$error_message" 
         append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
         update_skipped "$YAML_SUMMARY_FILE" "$meter_id"
+        increase_meters_failed "$YAML_SUMMARY_FILE"
     fi
 
     # Append meter information after processing
@@ -112,6 +115,6 @@ for ((i = 0; i < num_meters; i++)); do
 done
 
 download_end_time=$(date -u --iso-8601=seconds)
-append_timestamps "$YAML_SUMMARY_FILE" "$download_start_time" "$download_end_time" "download"
+append_timestamps "$YAML_SUMMARY_FILE" "$download_start_time" "$download_end_time" "summary"
 
 log "All meters have been processed"

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -101,7 +101,7 @@ for ((i = 0; i < num_meters; i++)); do
         error_code=$download_return_code
         error_message="Download failed for meter: $meter_id"
         meter_status="failure"
-        warning "$error_message" "$error_code"
+        warning "$error_code" "$error_message" 
         append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
         update_skipped "$YAML_SUMMARY_FILE" "$meter_id"
     fi

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -17,6 +17,7 @@
 current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/common_utils.sh"
+source "$current_dir/yaml_summary.sh"
 
 LOCKFILE="/var/lock/$script_name" # Define the lock file path using script's basename
 
@@ -64,12 +65,21 @@ fi
 output_dir="$download_dir/$location/$data_type"
 mkdir -p "$output_dir" && log "Directory created successfully: $output_dir" || failure $STREAMS_DIR_CREATION_FAIL "Failed to create directory: $output_dir"
 
+# Initialize log summary
+TIMESTAMP=$(date +"%Y%m%d_%H%M")
+LOG_DIR="$download_dir/logs"
+mkdir -p "$LOG_DIR"
+YAML_SUMMARY_FILE="$LOG_DIR/download_summary_$TIMESTAMP.yml"
+export YAML_SUMMARY_FILE
+init_summary "$YAML_SUMMARY_FILE"
+
 # Loop through the meters and download the event files
 for ((i = 0; i < num_meters; i++)); do
     meter_type=$(yq ".meters[$i].type" $config_path)
     meter_ip=$(yq ".meters[$i].ip" $config_path)
     meter_id=$(yq ".meters[$i].id" $config_path)
-
+    meter_start_time=$(date -u --iso-8601=seconds)
+    init_meter_summary "$YAML_SUMMARY_FILE" "$meter_id" "$meter_start_time"
     # Use the default credentials if specific meter credentials are not provided
     meter_username=$(yq ".meters[$i].credentials.username // strenv(default_username)" $config_path)
     meter_password=$(yq ".meters[$i].credentials.password // strenv(default_password)" $config_path)
@@ -81,9 +91,19 @@ for ((i = 0; i < num_meters; i++)); do
     # Execute download script and check its success in one step
     if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit" "$data_type" "$location" "$max_age_days" "$max_conection_retries"; then
         log "Download complete for meter: $meter_id"
+        meter_status="success"
+        error_code=""
+        error_message=""
     else
-        warning "Download incomplete for meter: $meter_id"
+        error_code=$STREAMS_DOWNLOAD_FAIL
+        error_message="Download failed for meter: $meter_id"
+        meter_status="failure"
+        warning "$error_message" "$error_code"
     fi
+    meter_end_time=$(date -u --iso-8601=seconds)
+
+    # Append meter information after processing
+    append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status" "$meter_start_time" "$meter_end_time" "$error_code" "$error_message" 
 done
 
 log "All meters have been processed"

--- a/cli_meter/data_pipeline.sh
+++ b/cli_meter/data_pipeline.sh
@@ -92,18 +92,17 @@ for ((i = 0; i < num_meters; i++)); do
     if "$current_dir/meters/$meter_type/download.sh" "$meter_ip" "$output_dir" "$meter_id" "$meter_type" "$bandwidth_limit" "$data_type" "$location" "$max_age_days" "$max_conection_retries"; then
         log "Download complete for meter: $meter_id"
         meter_status="success"
-        error_code=""
-        error_message=""
     else
         error_code=$STREAMS_DOWNLOAD_FAIL
         error_message="Download failed for meter: $meter_id"
         meter_status="failure"
         warning "$error_message" "$error_code"
+        append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
     fi
     meter_end_time=$(date -u --iso-8601=seconds)
 
     # Append meter information after processing
-    append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status" "$meter_start_time" "$meter_end_time" "$error_code" "$error_message" 
+    append_meter "$YAML_SUMMARY_FILE" "$meter_id" "$meter_status"  "$meter_end_time"
 done
 
 log "All meters have been processed"

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -30,16 +30,16 @@ handle_sig() {
 
     case $sig in
         SIGINT)
-            failure $STREAMS_SIGINT "SIGINT received. Exiting..."
+            failure $STREAMS_SIGINT "SIGINT received, exiting"
             ;;
         SIGQUIT)
-            failure $STREAMS_SIGQUIT "SIGQUIT received. Exiting..."
+            failure $STREAMS_SIGQUIT "SIGQUIT received, exiting"
             ;;
         SIGTERM)
-            failure $STREAMS_SIGTERM "SIGTERM received. Exiting..."
+            failure $STREAMS_SIGTERM "SIGTERM received, exiting"
             ;;
         *)
-            failure $STREAMS_UNKNOWN "Unknown signal received. Exiting..."
+            failure $STREAMS_UNKNOWN "Unknown signal received, exiting"
             ;;
     esac
 }
@@ -75,10 +75,9 @@ mark_event_incomplete() {
 
     # Move the current directory to its new incomplete name
     mv "$original_dir" "${base_incomplete_dir}_${suffix}"
-    log "" # Add a new line for better readability
     log "Moved event $event_id to ${event_id}.incomplete_${suffix}"
   else
-    warning "Directory $original_dir does not exist." "$STREAMS_DIR_NOT_FOUND"
+    warning $STREAMS_DIR_NOT_FOUND "Directory $original_dir does not exist" 
   fi
 }
 

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -78,7 +78,7 @@ mark_event_incomplete() {
     log "" # Add a new line for better readability
     log "Moved event $event_id to ${event_id}.incomplete_${suffix}"
   else
-    warning "Directory $original_dir does not exist."
+    warning "Directory $original_dir does not exist." "$STREAMS_DIR_NOT_FOUND"
   fi
 }
 

--- a/cli_meter/meters/sel735/common_sel735.sh
+++ b/cli_meter/meters/sel735/common_sel735.sh
@@ -93,6 +93,25 @@ validate_download() {
     return 0 # True - All files are present
 }
 
+get_total_event_files_size() {
+    local event_dir=$1
+    local event_id=$2
+    local total_size=0
+
+    # Files expected to have downloaded
+    local expected_files=("CEV_${event_id}.CEV" "HR_${event_id}.CFG" "HR_${event_id}.DAT" "HR_${event_id}.HDR" "HR_${event_id}.ZDAT")
+
+    for file in "${expected_files[@]}"; do
+        if [ -f "${event_dir}/${file}" ]; then
+            file_size=$(stat -c %s "${event_dir}/${file}")
+            total_size=$((total_size + file_size))
+        fi
+    done
+
+    # Convert to KB
+    total_files_size_kb=$(echo "scale=4; $total_size / 1024" | bc)
+    echo "$total_files_size_kb"
+}
 # Wrapper function to validate the complete directory
 validate_complete_directory() {
     local event_dir=$1

--- a/cli_meter/meters/sel735/create_message.sh
+++ b/cli_meter/meters/sel735/create_message.sh
@@ -39,5 +39,5 @@ json_payload=$(jq -n \
     '{event_id: $eid, filename: $fn, path: $pth, data_type: $dt}')
 
 # Write the JSON payload to the .message file
-echo "$json_payload" > "$message_file" && log "Created message file: $message_file" || warning "Failed to write to message file: $message_file"
+echo "$json_payload" > "$message_file" && log "Created message file: $message_file" || failure $STREAMS_FILE_CREATION_FAIL "Failed to write to message file: $message_file"
 

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -24,6 +24,20 @@
 #                     download_event.sh, generate_event_metadata.sh, zip_event.sh
 #                     create_message.sh
 # ==============================================================================
+handle_failure() {
+  local event_id=$1
+  local output_dir=$2
+  local error_code=$3
+  local error_message=$4
+  local yaml_file=$5
+  local meter_id=$6
+
+  mark_event_incomplete "$event_id" "$output_dir"
+  warning "$error_code" "$error_message"
+  append_error "$yaml_file" "$meter_id" "$error_code" "$error_message"
+  append_event "$yaml_file" "$meter_id" "$event_id" "failure"
+}
+
 current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh"
@@ -76,6 +90,7 @@ for event_info in $events; do
 
   # Update current_event_id for mark_event_incomplete
   current_event_id=$event_id
+  event_status=""
 
   # Update output_dir
   output_dir="$base_output_dir/$date_dir/$meter_id"
@@ -86,39 +101,29 @@ for event_info in $events; do
   # Download event directory (5 files)
   if "$current_dir/download_event.sh" "$meter_ip" "$event_id" "$output_dir" "$bandwidth_limit"; then
     event_status="success"
-    error_message=""
-    error_code=""
   else
-    mark_event_incomplete "$event_id" "$output_dir"
-    event_status="failure"
-    error_message="Failed to download event files for event_id: $event_id"
-    error_code=$STREAMS_DOWNLOAD_FAIL
-    warning "$error_message" $error_code
-    append_error "$YAML_SUMMARY_FILE" $meter_id $error_code "$error_message"
+    handle_failure "$event_id" "$output_dir" "$STREAMS_DOWNLOAD_FAIL" "Failed to download event files for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    continue
   fi
-
-  # Append event information after processing
-  append_event "$YAML_SUMMARY_FILE" $meter_id $event_id $event_status
 
   download_end=$(date -u --iso-8601=seconds)
   
   # Validate the downloaded files
   validate_download "$output_dir/$event_id" "$event_id" && log "Downloaded files validated for event: $event_id" || {
-    log "Not all files downloaded for event: $event_id"
-    mark_event_incomplete "$event_id" "$output_dir"
+    handle_failure "$event_id" "$output_dir" "$STREAMS_UNKNOWN" "Failed to validate event files for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
     continue
   }
 
   # Generate metadata for the event
   "$current_dir/generate_metadata_yml.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_start" "$download_end" || {
-    mark_event_incomplete "$event_id" "$output_dir"
-    failure $STREAMS_METADATA_FAIL "Failed to generate metadata"
+    handle_failure "$event_id" "$output_dir" "$STREAMS_METADATA_FAIL" "Failed to generate metadata for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    continue
   }
 
   # Validate the metadata files
   validate_complete_directory "$output_dir/$event_id" "$event_id" && log "Metadata files validated for event: $event_id" || {
-    mark_event_incomplete "$event_id" "$output_dir"
-    failure $STREAMS_INCOMPLETE_DIR "Missing metadata file in event directory"
+    handle_failure "$event_id" "$output_dir" "$STREAMS_INCOMPLETE_DIR" "Missing metadata file in event directory for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    continue
   }
 
   # Zip the event directory, including all files and the checksum.md5 file
@@ -131,14 +136,15 @@ for event_info in $events; do
 
   # Zip the event files and empty the working event directory
   "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$zip_filename"|| {
-    mark_event_incomplete "$event_id" "$output_dir"
-    failure $STREAMS_ZIP_FAIL "Failed to zip event files"
+    handle_failure "$event_id" "$output_dir" "$STREAMS_ZIP_FAIL" "Failed to zip event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    continue
   }
 
   # Create the message file (JSON) for the event
   "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$path" "$data_type" "$event_zipped_output_dir" || {
-    mark_event_incomplete "$event_id" "$output_dir"
-    warning "Failed to create message file" $STREAMS_FILE_CREATION_FAIL
+    handle_failure "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    continue
   }
 
+  append_event "$YAML_SUMMARY_FILE" $meter_id $event_id "$event_status"
 done

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -34,8 +34,8 @@ handle_failure() {
 
   mark_event_incomplete "$event_id" "$output_dir"
   warning "$error_code" "$error_message"
-  append_error "$yaml_file" "$meter_id" "$error_code" "$error_message"
-  append_event "$yaml_file" "$meter_id" "$event_id" "failure"
+  #append_error "$yaml_file" "$meter_id" 
+  append_event "$yaml_file" "$meter_id" "$event_id" "failure" "$error_code" "$error_message"
 }
 
 current_dir=$(dirname "$(readlink -f "$0")")

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -65,6 +65,10 @@ events=$("$current_dir/get_events.sh" "$meter_ip" "$meter_id" "$base_output_dir"
 # Check if there are any events to download
 [ -z "$events" ] && log "No new events to download for meter: $meter_id" && exit 0
 
+total_events=$(echo "$events" | wc -l)
+
+init_event_summary "$YAML_SUMMARY_FILE" "$meter_id" $total_events
+
 # output_dir is the location where the data will be stored
 for event_info in $events; do
   IFS=',' read -r event_id date_dir event_timestamp <<<"$event_info"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -85,7 +85,7 @@ for event_info in $events; do
     error_message=""
     error_code=""
   else
-    mark_event_incomplete
+    mark_event_incomplete "$event_id" "$output_dir"
     event_status="failure"
     error_message="Failed to download event files for event_id: $event_id"
     error_code=$STREAMS_DOWNLOAD_FAIL
@@ -107,13 +107,13 @@ for event_info in $events; do
 
   # Generate metadata for the event
   "$current_dir/generate_metadata_yml.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_start" "$download_end" || {
-    mark_event_incomplete
+    mark_event_incomplete "$event_id" "$output_dir"
     failure $STREAMS_METADATA_FAIL "Failed to generate metadata"
   }
 
   # Validate the metadata files
   validate_complete_directory "$output_dir/$event_id" "$event_id" && log "Metadata files validated for event: $event_id" || {
-    mark_event_incomplete
+    mark_event_incomplete "$event_id" "$output_dir"
     failure $STREAMS_INCOMPLETE_DIR "Missing metadata file in event directory"
   }
 
@@ -127,13 +127,13 @@ for event_info in $events; do
 
   # Zip the event files and empty the working event directory
   "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$zip_filename"|| {
-    mark_event_incomplete
+    mark_event_incomplete "$event_id" "$output_dir"
     failure $STREAMS_ZIP_FAIL "Failed to zip event files"
   }
 
   # Create the message file (JSON) for the event
   "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$path" "$data_type" "$event_zipped_output_dir" || {
-    mark_event_incomplete
+    mark_event_incomplete "$event_id" "$output_dir"
     warning "Failed to create message file" $STREAMS_FILE_CREATION_FAIL
   }
 

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -24,17 +24,20 @@
 #                     download_event.sh, generate_event_metadata.sh, zip_event.sh
 #                     create_message.sh
 # ==============================================================================
-handle_failure() {
+handle_fail() {
   local event_id=$1
   local output_dir=$2
   local error_code=$3
   local error_message=$4
   local yaml_file=$5
   local meter_id=$6
+  local download_start=$7
+  local download_end=$8
+  local download_size=$(get_total_event_files_size "$output_dir/$event_id" "$event_id")
 
   mark_event_incomplete "$event_id" "$output_dir"
   warning "$error_code" "$error_message"
-  append_event "$yaml_file" "$meter_id" "$event_id" "failure" "$error_code" "$error_message"
+  append_event "$yaml_file" "$meter_id" "$event_id" "failure" "$download_start" "$download_end" "$download_size" "$error_code" "$error_message"
 }
 
 current_dir=$(dirname "$(readlink -f "$0")")
@@ -100,28 +103,30 @@ for event_info in $events; do
   # Download event directory (5 files)
   if "$current_dir/download_event.sh" "$meter_ip" "$event_id" "$output_dir" "$bandwidth_limit"; then
     event_status="success"
+    download_end=$(date -u --iso-8601=seconds)
+    log "DOWNLOAD: download"
+    download_size=$(get_total_event_files_size "$output_dir/$event_id" "$event_id")
   else
-    handle_failure "$event_id" "$output_dir" "$STREAMS_DOWNLOAD_FAIL" "Failed to download event files for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    download_end=$(date -u --iso-8601=seconds)
+    handle_fail "$event_id" "$output_dir" "$STREAMS_DOWNLOAD_FAIL" "Failed to download event files for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end"
     continue
   fi
-
-  download_end=$(date -u --iso-8601=seconds)
   
   # Validate the downloaded files
   validate_download "$output_dir/$event_id" "$event_id" && log "Downloaded files validated for event: $event_id" || {
-    handle_failure "$event_id" "$output_dir" "$STREAMS_UNKNOWN" "Failed to validate event files for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    handle_fail "$event_id" "$output_dir" "$STREAMS_UNKNOWN" "Failed to validate event files for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end"
     continue
   }
 
   # Generate metadata for the event
   "$current_dir/generate_metadata_yml.sh" "$event_id" "$output_dir" "$meter_id" "$meter_type" "$event_timestamp" "$download_start" "$download_end" || {
-    handle_failure "$event_id" "$output_dir" "$STREAMS_METADATA_FAIL" "Failed to generate metadata for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    handle_fail "$event_id" "$output_dir" "$STREAMS_METADATA_FAIL" "Failed to generate metadata for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end"
     continue
   }
 
   # Validate the metadata files
   validate_complete_directory "$output_dir/$event_id" "$event_id" && log "Metadata files validated for event: $event_id" || {
-    handle_failure "$event_id" "$output_dir" "$STREAMS_INCOMPLETE_DIR" "Missing metadata file in event directory for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    handle_fail "$event_id" "$output_dir" "$STREAMS_INCOMPLETE_DIR" "Missing metadata file in event directory for event_id: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end"
     continue
   }
 
@@ -135,15 +140,15 @@ for event_info in $events; do
 
   # Zip the event files and empty the working event directory
   "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$zip_filename"|| {
-    handle_failure "$event_id" "$output_dir" "$STREAMS_ZIP_FAIL" "Failed to zip event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    handle_fail "$event_id" "$output_dir" "$STREAMS_ZIP_FAIL" "Failed to zip event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end"
     continue
   }
 
   # Create the message file (JSON) for the event
   "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$path" "$data_type" "$event_zipped_output_dir" || {
-    handle_failure "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id"
+    handle_fail "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id" "$YAML_SUMMARY_FILE" "$meter_id" "$download_start" "$download_end" 
     continue
   }
 
-  append_event "$YAML_SUMMARY_FILE" $meter_id $event_id "$event_status"
+  append_event "$YAML_SUMMARY_FILE" $meter_id $event_id "$event_status" "$download_start" "$download_end" "$download_size"
 done

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -90,11 +90,11 @@ for event_info in $events; do
     error_message="Failed to download event files for event_id: $event_id"
     error_code=$STREAMS_DOWNLOAD_FAIL
     warning "$error_message" $error_code
-    append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
+    append_error "$YAML_SUMMARY_FILE" $meter_id $error_code "$error_message"
   fi
 
   # Append event information after processing
-  append_event "$YAML_SUMMARY_FILE" "$meter_id" "$event_id" "$event_status"
+  append_event "$YAML_SUMMARY_FILE" $meter_id $event_id $event_status
 
   download_end=$(date -u --iso-8601=seconds)
   

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -34,7 +34,6 @@ handle_failure() {
 
   mark_event_incomplete "$event_id" "$output_dir"
   warning "$error_code" "$error_message"
-  #append_error "$yaml_file" "$meter_id" 
   append_event "$yaml_file" "$meter_id" "$event_id" "failure" "$error_code" "$error_message"
 }
 

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -82,16 +82,19 @@ for event_info in $events; do
   # Download event directory (5 files)
   if "$current_dir/download_event.sh" "$meter_ip" "$event_id" "$output_dir" "$bandwidth_limit"; then
     event_status="success"
+    error_message=""
+    error_code=""
   else
     mark_event_incomplete
     event_status="failure"
     error_message="Failed to download event files for event_id: $event_id"
     error_code=$STREAMS_DOWNLOAD_FAIL
     warning "$error_message" $error_code
+    append_error "$YAML_SUMMARY_FILE" "$meter_id" "$error_code" "$error_message"
   fi
 
   # Append event information after processing
-  append_event "$YAML_SUMMARY_FILE" "$meter_id" "$event_id" "$event_status" "$error_message" "$error_code"
+  append_event "$YAML_SUMMARY_FILE" "$meter_id" "$event_id" "$event_status"
 
   download_end=$(date -u --iso-8601=seconds)
   

--- a/cli_meter/meters/sel735/generate_metadata_yml.sh
+++ b/cli_meter/meters/sel735/generate_metadata_yml.sh
@@ -83,6 +83,17 @@ done
 
 # Calculate download_time and download_speed
 download_time=$(($(date -d "$download_end" +%s) - $(date -d "$download_start" +%s)))
+
+if [ "$download_time" -eq 0 ]; then
+    download_time=1
+    log "Download time is zero, setting it to 1 second"
+fi
+
+if [ "$total_files_size" -eq 0 ]; then
+    log "Total files size is zero, setting it to 1 byte"
+    total_files_size=1
+fi
+
 download_speed=$(echo "scale=2; $total_files_size / $download_time" | bc)
 log "Download start: $download_start"
 log "Download end: $download_end"

--- a/cli_meter/meters/sel735/generate_metadata_yml.sh
+++ b/cli_meter/meters/sel735/generate_metadata_yml.sh
@@ -5,7 +5,7 @@
 #                     using environment variables and outputs it in YML format.
 #
 # Usage:              ./generate_and_create_metadata.sh <event_id> <event_dir> <meter_id>
-#                     <meter_type> <event_timestamp> <download_start> <download_end>
+#                     <meter_type> <event_timestamp> <started_at> <completed_at>
 #
 # Arguments:
 #   event_id          Event ID
@@ -13,25 +13,26 @@
 #   meter_id          Meter ID
 #   meter_type        Meter type
 #   event_timestamp   Original timestamp of the event
-#   download_start    Timestamp of when the download started
-#   download_end      Timestamp of when the download ended
+#   started_at    Timestamp of when the download started
+#   completed_at      Timestamp of when the download ended
 #
 # Requirements:       common_utils.sh
 # ==============================================================================
 current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh"
+source "$current_dir/common_sel735.sh"
 
 # Check if the correct number of arguments are passed
-[ "$#" -ne 7 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <event_id> <event_dir> <meter_id> <meter_type> <event_timestamp> <download_start> <download_end>"
+[ "$#" -ne 7 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <event_id> <event_dir> <meter_id> <meter_type> <event_timestamp> <started_at> <completed_at>"
 
 event_id=$1
 event_dir="$2/$event_id" # Assumes location/data_type/working/YYYY-MM/meter_id/event_id
 meter_id=$3
 meter_type=$4
 event_timestamp=$5
-download_start=$6
-download_end=$7
+started_at=$6
+completed_at=$7
 
 metadata_file="${event_id}_metadata.yml"
 metadata_path="$event_dir/$metadata_file"
@@ -44,24 +45,22 @@ checksum_file="$event_dir/checksum.md5"
     echo "meter_id: \"$meter_id\""
     echo "meter_type: \"$meter_type\""
     echo "data_level: \"level0\""
-    echo "download_start: \"$download_start\""
-    echo "download_end: \"$download_end\""
+    echo "started_at: \"$started_at\""
+    echo "completed_at: \"$completed_at\""
     echo "duration: \"\""
+    echo "download_size: \"\""
     echo "download_speed: \"\""
-    echo "total_files_size: \"\""
     echo ""
     echo "files:"
 } > "$metadata_path" && log "Initialized metadata file: $metadata_path"
 
 log "Creating metadata for event: $event_id"
 
-total_files_size=0
-
 for file in "$event_dir"/*; do
     filename=$(basename "$file")
     if [ -s "$file" ]; then
-        # Skip if the file is a metadata file
-        if [[ "$file" == *_metadata.yml ]]; then
+        # Skip if the file is a metadata file or the checksum file
+        if [[ "$filename" == *_metadata.yml || "$filename" == "checksum.md5" ]]; then
             log "Skipping metadata creation for: $filename"
             continue
         fi
@@ -69,9 +68,6 @@ for file in "$event_dir"/*; do
         echo "$checksum $filename" >> "$checksum_file" && log "Checksum generated and added to checksum.md5 for file: $filename"
 
         # Append file metadata to the main metadata file
-        file_size=$(stat -c%s "$file")
-        total_files_size=$((total_files_size + file_size))
-
         {
             echo "  - file_name: $filename"
             echo "    md5: \"$checksum\""
@@ -82,27 +78,22 @@ for file in "$event_dir"/*; do
 done
 
 # Calculate duration and download_speed
-duration=$(($(date -d "$download_end" +%s) - $(date -d "$download_start" +%s)))
-
+duration=$(($(date -d "$completed_at" +%s) - $(date -d "$started_at" +%s)))
 [[ "$duration" -eq 0 ]] && duration=1 && log "Download time is zero, setting it to 1 second"
-[[ "$total_files_size" -eq 0 ]] && log "Total files size is zero, setting it to 1 byte" && total_files_size=1
 
-# Convert bytes to kilobytes and round to 2 decimal places
-total_files_size_kb=$(echo "scale=4; $total_files_size / 1024" | bc)
-download_speed_kbps=$(echo "scale=4; $total_files_size_kb / $duration" | bc)
+download_size_kb=$(get_total_event_files_size "$event_dir" "$event_id")
+is_zero=$(echo "$download_size_kb <= 0" | bc)
+[[ "$is_zero" -eq 1 ]] && log "Total files size is zero, setting it to 1 kilobyte" && download_size_kb=1
 
-total_files_size_fmt=$(numfmt --to=iec --suffix=B --format="%.4f" "$total_files_size_kb")
-download_speed_fmt=$(numfmt --to=iec --suffix=Bps --format="%.4f" "$download_speed_kbps")
-
-log "Download start: $download_start"
-log "Download end: $download_end"
-log "Total files size: $total_files_size_fmt"
+download_speed_kbps=$(echo "scale=4; $download_size_kb / $duration" | bc)
+log "Calculated metadata for event: $event_id"
+log "Download size: ${download_size_kb}KB"
 log "Download duration: ${duration}s"
-log "Download speed: $download_speed_fmt"
+log "Download speed: ${download_speed_kbps}KBps"
 
 # Append calculated fields to metadata
 sed -i "s/duration: \"\"/duration: \"${duration}s\"/" "$metadata_path"
-sed -i "s/download_speed: \"\"/download_speed: \"$download_speed_fmt\"/" "$metadata_path"
-sed -i "s/total_files_size: \"\"/total_files_size: \"$total_files_size_fmt\"/" "$metadata_path"
+sed -i "s/download_speed: \"\"/download_speed: \"${download_speed_kbps}KBps\"/" "$metadata_path"
+sed -i "s/download_size: \"\"/download_size: \"${download_size_kb}KB\"/" "$metadata_path"
 
 log "Final metadata appended to: $metadata_path"

--- a/cli_meter/yaml_summary.sh
+++ b/cli_meter/yaml_summary.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# ==============================================================================
+# Script Name:        log_summary.sh
+# Description:        This script handles the creation and appending of entries
+#                     to a summary log file in YAML format.
+#
+# Operations:
+#   init_summary      Initializes the log file
+#   append_meter      Appends meter information to the log file
+#   append_event      Appends event information to the log file
+#
+# Arguments for 'init_summary':
+#   <yaml_file>       Path to the YAML file to initialize
+#
+# Arguments for 'append_meter':
+#   <yaml_file>       Path to the YAML file
+#   <meter_name>      Name of the meter
+#   <status>          Status of the download (success/failure)
+#   <started_at>      Start time of the download
+#   <completed_at>    End time of the download
+#   <error_code>      Error code (optional)
+#   <error_message>   Error message (optional)
+#
+# Arguments for 'append_event':
+#   <yaml_file>       Path to the YAML file
+#   <meter_name>      Name of the meter
+#   <event_id>        ID of the event
+#   <event_status>    Status of the event (success/failure)
+#   <error_code>      Error code (optional)
+#   <error_message>   Error message (optional)
+# ==============================================================================
+
+init_summary() {
+  local yaml_file=$1
+  local dir
+  dir=$(dirname "$yaml_file")
+  
+  # Create the directory if it does not exist
+  mkdir -p "$dir"
+  
+}
+
+init_meter_summary() {
+  local yaml_file=$1
+  local meter_name=$2
+  local started_at=$3
+  {
+      echo "meters:"
+      echo "  - name: $meter_name"
+      echo "    status:"
+      echo "    warnings:"
+      echo "    errors:"
+      echo "    events:"
+      echo "      total: 0"
+      echo "      downloaded: 0"
+      echo "      failed: 0"
+      echo "    started_at: $started_at"
+      echo "    completed_at: "
+  } > "$yaml_file"
+}
+
+append_meter() {
+  local yaml_file=$1
+  local meter_name=$2
+  local status=$3
+  local started_at=$4
+  local completed_at=$5
+  local error_code=$6
+  local error_message=$7
+
+  {
+      echo "  - name: $meter_name"
+      echo "    status: $status"
+      echo "    warnings:"
+      echo "    errors:"
+      [[ -n "$error_code" && -n "$error_message" ]] && echo "      - code: $error_code"
+      [[ -n "$error_message" ]] && echo "        message: $error_message"
+      echo "    events:"
+      echo "      total: 0"
+      echo "      downloaded: 0"
+      echo "      failed: 0"
+      echo "    started_at: $started_at"
+      echo "    completed_at: $completed_at"
+  } >> "$yaml_file"
+}
+
+append_event() {
+  local yaml_file=$1
+  local meter_name=$2
+  local event_id=$3
+  local event_status=$4
+  local error_code=$5
+  local error_message=$6
+
+  log "Appending event: $event_id for meter: $meter_name"
+  log "Event status: $event_status"
+  log "Error code: $error_code"
+  log "Error message: $error_message"
+}
+
+export -f init_summary
+export -f init_meter_summary
+export -f append_meter
+export -f append_event

--- a/cli_meter/yaml_summary.sh
+++ b/cli_meter/yaml_summary.sh
@@ -50,9 +50,7 @@ init_meter_summary() {
     \"name\": \"$meter_name\",
     \"status\": \"\",
     \"started_at\": \"$started_at\",
-    \"completed_at\": \"\",
-    \"events\": [],
-    \"errors\": []
+    \"completed_at\": \"\"
   }"
 
   yq e -i ".meters += [$meter_template]" "$yaml_file"
@@ -75,8 +73,9 @@ append_event() {
   local meter_name=$2
   local event_id=$3
   local event_status=$4
-  local error_code=$5
-  local error_message=$6
+
+  # Add the events array if it doesn't exist
+  yq e -i "( .meters[] | select(.name == \"$meter_name\") | .events ) = ( .meters[] | select(.name == \"$meter_name\") | .events // [] )" "$yaml_file"
 
   # Create the event template
   event_template="{
@@ -92,13 +91,16 @@ append_event() {
 append_error(){
   local yaml_file=$1
   local meter_name=$2
-  local error_code=$3
-  local error_message=$4
+  local exit_code=$3
+  local message=$4
+
+  # Add the errors array if it doesn't exist
+  yq e -i "( .meters[] | select(.name == \"$meter_name\") | .errors ) = ( .meters[] | select(.name == \"$meter_name\") | .errors // [] )" "$yaml_file"
 
   # Create the error template
   error_template="{
-    \"error_code\": \"$error_code\",
-    \"error_message\": \"$error_message\"
+    \"exit_code\": \"$exit_code\",
+    \"message\": \"$message\"
   }"
 
   # Append the error to the specified meter's errors array

--- a/cli_meter/yaml_summary.sh
+++ b/cli_meter/yaml_summary.sh
@@ -7,38 +7,67 @@
 #
 # Operations:
 #   init_summary      Initializes the log file
-#   append_meter      Appends meter information to the log file
+#   init_meter_summary Initializes a meter entry in the log file
+#   append_info       Appends general information to the log file
+#   append_meter      Appends meter completion information to the log file
 #   append_event      Appends event information to the log file
+#   append_error      Appends error information to the log file
+#   append_timestamps Appends start and end timestamps with duration calculation
+#   calculate_duration Calculates the duration between two timestamps
 #
 # Arguments for 'init_summary':
 #   <yaml_file>       Path to the YAML file to initialize
+#   <started_at>      Start time of the download
+#
+# Arguments for 'init_meter_summary':
+#   <yaml_file>       Path to the YAML file
+#   <meter_name>      Name of the meter
+#   <started_at>      Start time of the meter download
+#
+# Arguments for 'append_info':
+#   <yaml_file>       Path to the YAML file
+#   <key>             Key to append
+#   <value>           Value to append
 #
 # Arguments for 'append_meter':
 #   <yaml_file>       Path to the YAML file
 #   <meter_name>      Name of the meter
 #   <status>          Status of the download (success/failure)
-#   <started_at>      Start time of the download
 #   <completed_at>    End time of the download
-#   <error_code>      Error code (optional)
-#   <error_message>   Error message (optional)
 #
 # Arguments for 'append_event':
 #   <yaml_file>       Path to the YAML file
 #   <meter_name>      Name of the meter
 #   <event_id>        ID of the event
 #   <event_status>    Status of the event (success/failure)
-#   <error_code>      Error code (optional)
-#   <error_message>   Error message (optional)
+#
+# Arguments for 'append_error':
+#   <yaml_file>       Path to the YAML file
+#   <meter_name>      Name of the meter
+#   <exit_code>       Exit code of the error
+#   <message>         Error message
+#
+# Arguments for 'append_timestamps':
+#   <yaml_file>       Path to the YAML file
+#   <started_at>      Start time
+#   <completed_at>    End time
+#   <type>            Type (e.g., download or meter)
 # ==============================================================================
+
 
 init_summary() {
   local yaml_file=$1
-  local dir
-  dir=$(dirname "$yaml_file")
-  
-  # Create the directory if it does not exist
+  local started_at=$2
+  local dir=$(dirname "$yaml_file")
   mkdir -p "$dir"
-  echo "meters:" > "$yaml_file"
+
+
+  echo "download:" >> "$yaml_file"
+  echo "  started_at: \"$started_at\"" >> "$yaml_file"
+  echo "  completed_at: \"\"" >> "$yaml_file"
+  echo "  duration: \"\"" >> "$yaml_file"
+  echo "meters:" >> "$yaml_file"
+  
 }
 
 init_meter_summary() {
@@ -50,22 +79,36 @@ init_meter_summary() {
     \"name\": \"$meter_name\",
     \"status\": \"\",
     \"started_at\": \"$started_at\",
-    \"completed_at\": \"\"
+    \"completed_at\": \"\",
+    \"duration\": \"\"
   }"
 
   yq e -i ".meters += [$meter_template]" "$yaml_file"
+}
+
+append_info() {
+  local yaml_file=$1
+  local key=$2
+  local value=$3
+
+  yq e -i ".${key} = \"$value\"" "$yaml_file"
 }
 
 append_meter() {
   local yaml_file=$1
   local meter_name=$2
   local status=$3
-  local completed_at=$4
-  local error_code=$5
-  local error_message=$6
+  local started_at=$4
+  local completed_at=$5
 
   yq e -i "( .meters[] | select(.name == \"$meter_name\") | .status) = \"$status\"" "$yaml_file"
   yq e -i "( .meters[] | select(.name == \"$meter_name\") | .completed_at) = \"$completed_at\"" "$yaml_file"
+
+  started_at=$(yq e ".meters[] | select(.name == \"$meter_name\") | .started_at" "$yaml_file")
+
+  duration=$(calculate_duration "$started_at" "$completed_at")
+  yq e -i "( .meters[] | select(.name == \"$meter_name\") | .duration) = \"$duration\"" "$yaml_file"
+
 }
 
 append_event() {
@@ -107,9 +150,34 @@ append_error(){
   yq e -i "( .meters[] | select(.name == \"$meter_name\") | .errors ) += [$error_template]" "$yaml_file"
 
 }
+append_timestamps() {
+  local yaml_file=$1
+  local started_at=$2
+  local completed_at=$3
+  local type=$4
+
+  yq e -i ".$type.started_at = \"$started_at\"" "$yaml_file"
+  yq e -i ".$type.completed_at = \"$completed_at\"" "$yaml_file"
+
+  duration=$(calculate_duration "$started_at" "$completed_at")
+  yq e -i ".$type.duration = \"$duration\"" "$yaml_file"
+
+}
+
+calculate_duration() {
+  local started_at=$1
+  local completed_at=$2
+
+  start_seconds=$(date -d "$started_at" +%s)
+  end_seconds=$(date -d "$completed_at" +%s)
+
+  duration=$((end_seconds - start_seconds))
+  echo $duration
+}
 
 export -f init_summary
 export -f init_meter_summary
 export -f append_meter
 export -f append_event
 export -f append_error
+export -f append_timestamps

--- a/cli_meter/yaml_summary.sh
+++ b/cli_meter/yaml_summary.sh
@@ -58,13 +58,18 @@
 init_summary() {
   local yaml_file=$1
   local started_at=$2
+  local meters_total=$3
   local dir=$(dirname "$yaml_file")
   mkdir -p "$dir"
 
-  echo "download:" >> "$yaml_file"
+  echo "summary:" >> "$yaml_file"
   echo "  started_at: \"$started_at\"" >> "$yaml_file"
   echo "  completed_at: \"\"" >> "$yaml_file"
   echo "  duration: \"\"" >> "$yaml_file"
+  echo "  meters_total: $meters_total" >> "$yaml_file"
+  echo "  meters_attempted: 0" >> "$yaml_file"
+  echo "  meters_successful: 0" >> "$yaml_file"
+  echo "  meters_failed: 0" >> "$yaml_file"
   echo "meters:" >> "$yaml_file"
   
 }
@@ -215,6 +220,21 @@ update_skipped() {
   yq e -i "( .meters[] | select(.name == \"$meter_name\") | .downloads.skipped ) = $skipped_events" "$yaml_file"
 }
 
+increase_meters_attemped() {
+  local yaml_file=$1
+  yq e -i ".summary.meters_attempted |= . + 1" "$yaml_file"
+}
+
+increase_meters_failed() {
+  local yaml_file=$1
+  yq e -i ".summary.meters_failed |= . + 1" "$yaml_file"
+}
+
+increase_meters_successful() {
+  local yaml_file=$1
+  yq e -i ".summary.meters_successful |= . + 1" "$yaml_file"
+}
+
 export -f init_summary
 export -f init_meter_summary
 export -f init_event_summary
@@ -223,3 +243,6 @@ export -f append_event
 export -f append_error
 export -f append_timestamps
 export -f update_skipped
+export -f increase_meters_attemped
+export -f increase_meters_failed
+export -f increase_meters_successful


### PR DESCRIPTION
This PR:
1.  **Creates download summary yaml file**
    - This file is downloaded to `events/summary/YYYY-MM/download_summary_YYYYMMDD_HHMM.yml`
    - overview
      - timestamps, duration
      - total meters, meters attempted, successful, failed 
    - status for event within each meter
      - any errors if failed 
    - status for each meter
      - The meters status is determined on the total number of events to download and how many were successful/failed 
3. **Updates bytes to KB in metadata file for each event** 
    - file change: `generate_metadata_yml.sh`
    - `bytes` to `KB`
    -`bytes/second` to `KBps`
4. **Debugs the `.incomplete` issue** 
    - this was because `mark_event_incomplete` wasn't being passed the correct parameters