### PR TITLE
Nicole/zip symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ config.yml
 >>>>>>> ot-dev-ftp-meter-download
 *.download_progress
 *.message
+config_*.yml
+archive_config_*.yml

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -134,10 +134,11 @@ for event_info in $events; do
 
   # LOCATION-TYPE-METER_ID-YYYYMM-EVENT_ID
   zip_filedate="${date_dir//-/}"
-  zip_filename="$location-$data_type-$meter_id-$zip_filedate-$event_id.zip"
-
+  symlink_name="$location-$data_type-$meter_id-$zip_filedate-$event_id"
+  zip_filename="${symlink_name}.zip"
+  
   # Zip the event files and empty the working event directory
-  "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$zip_filename"|| {
+  "$current_dir/zip_event.sh" "$output_dir" "$event_zipped_output_dir" "$event_id" "$symlink_name"|| {
     handle_fail "$event_id" "$output_dir" "$STREAMS_ZIP_FAIL" "Failed to zip event: $event_id" "$meter_id" "$download_start" "$download_end"
     continue
   }

--- a/cli_meter/test/test_helper/common.bash
+++ b/cli_meter/test/test_helper/common.bash
@@ -18,7 +18,8 @@ _common_setup() {
     EVENT_ID="1234"
     METER_IP="123.123.123"
     DATA_TYPE="events"
-    ZIP_FILENAME="$LOCATION-$METER_TYPE-$METER_ID-YYYYMM-$EVENT_ID.zip"
+    SYMLINK_NAME="$LOCATION-$METER_TYPE-$METER_ID-YYYYMM-$EVENT_ID"
+    ZIP_FILENAME="${SYMLINK_NAME}.zip"
 }
 
 _common_teardown() {

--- a/cli_meter/test/test_scripts.bats
+++ b/cli_meter/test/test_scripts.bats
@@ -45,9 +45,9 @@ teardown() {
 
 @test "zip_event.sh execution test" {
     mkdir -p "$TMP_DIR/$EVENT_ID"
-    run ./zip_event.sh "$TMP_DIR" "$TMP_DIR" "$EVENT_ID" "$ZIP_FILENAME"
+    run ./zip_event.sh "$TMP_DIR" "$TMP_DIR" "$EVENT_ID" "$SYMLINK_NAME"
     assert_success
-    assert_output --partial "Zipped files for event: $EVENT_ID"
+    assert_output --partial "Successfully zipped symlink: $SYMLINK_NAME to $TMP_DIR/$ZIP_FILENAME for event: $EVENT_ID"
     assert [ -f "$TMP_DIR/$ZIP_FILENAME" ]
     assert [ -d "$TMP_DIR/$EVENT_ID" ]
 }
@@ -55,10 +55,10 @@ teardown() {
 @test "zip_event.sh test 0 arguments" {
     run ./zip_event.sh
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
-    assert_output --partial "Usage: zip_event.sh <source_dir> <dest_dir> <event_id> <zip_filename>"
+    assert_output --partial "Usage: zip_event.sh <source_dir> <dest_dir> <event_id> <symlink_name>"
 }
 
 @test "zip_event.sh test invalid event_id" {
-    run ./zip_event.sh "$TMP_DIR" "$TMP_DIR" "not_a_directory" "$ZIP_FILENAME"
+    run ./zip_event.sh "$TMP_DIR" "$TMP_DIR" "not_a_directory" "$SYMLINK_NAME"
     assert_failure $(($STREAMS_DIR_NOT_FOUND % 256))
 }


### PR DESCRIPTION
This PR enhances the `zip_event.sh` script to create a symbolic link for the event directory, zip the contents via the symbolic link, and then remove the symbolic link. It also updates the `.gitignore` file to include `config_*.yml `and `archive_config_*.yml` to allow different versions of configurations with various values without tracking them in the repository.

**Changes:**

1. **Enhance zip_event.sh Script:**
    - Create a symbolic link for the event directory. `location-data_type-meter_id-YYYYMM-event_id`
    - Zip the contents via the symbolic link.
    - Remove the symbolic link after zipping.
    - Log detailed messages for each step for better traceability.
    - The final path of the zipped event directory is:
```bash
location/data_type/level0/YYYY-MM/meter_id/location-data_type-meter_id-YYYYMM-event_id.zip

ex. Event 10001
kea/events/level0/2023-12/sel00/kea-events-sel00-202312-10001.zip
```
2. **Update .gitignore:**
    - Add config_*.yml to ignore different versions of configuration files.
    - Add archive_config_*.yml to ignore different versions of archive configuration files.
