### PR TITLE
New Message File Format

### DIFF
--- a/cli_meter/meters/sel735/create_message.sh
+++ b/cli_meter/meters/sel735/create_message.sh
@@ -3,13 +3,13 @@
 # Script Name:        create_message.sh
 # Description:        This script creates a .message file with a JSON payload.
 #
-# Usage:              ./create_message.sh <event_id> <zip_filename> <path>
+# Usage:              ./create_message.sh <event_id> <zip_filename> <md5sum_value>
 #                     <data_type> <output_dir>
 #
 # Arguments:
 #   event_id          event ID
 #   zip_filename      Name of the zipped file
-#   path              Path to file
+#   md5sum_value      md5sum of the zipped file
 #   data_type         Type of data
 #   output_dir        Directory where the message file will be stored
 #
@@ -21,11 +21,11 @@ script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh" 
 
 # Check for exactly 5 arguments
-[ "$#" -ne 5 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <event_id> <zip_filename> <path> <data_type> <output_dir>"
+[ "$#" -ne 5 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 
 event_id="$1"
 zip_filename="$2"
-path="$3"
+md5sum_value="$3"
 data_type="$4"
 output_dir="$5"
 message_file="$output_dir/${zip_filename}.message"
@@ -34,9 +34,9 @@ message_file="$output_dir/${zip_filename}.message"
 json_payload=$(jq -n \
     --arg eid "$event_id" \
     --arg fn "$zip_filename" \
-    --arg pth "$path" \
+    --arg md5s "$md5sum_value" \
     --arg dt "$data_type" \
-    '{event_id: $eid, filename: $fn, path: $pth, data_type: $dt}')
+    '{event_id: $eid, filename: $fn, md5sum: $md5s, data_type: $dt}')
 
 # Write the JSON payload to the .message file
 echo "$json_payload" > "$message_file" && log "Created message file: $message_file" || failure $STREAMS_FILE_CREATION_FAIL "Failed to write to message file: $message_file"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -143,8 +143,11 @@ for event_info in $events; do
     continue
   }
 
+  # Calculate md5sum of the zipped file
+  md5sum_value=$(md5sum "$event_zipped_output_dir/$zip_filename" | awk '{print $1}')
+
   # Create the message file (JSON) for the event
-  "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$path" "$data_type" "$event_zipped_output_dir" || {
+  "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$md5sum_value" "$data_type" "$event_zipped_output_dir" || {
     handle_fail "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id"  "$meter_id" "$download_start" "$download_end" 
     continue
   }

--- a/cli_meter/test/test_scripts.bats
+++ b/cli_meter/test/test_scripts.bats
@@ -22,13 +22,13 @@ teardown() {
 @test "create_message.sh test 0 arguments" {
     run ./create_message.sh
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
-    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <path> <data_type> <output_dir>"
+    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 }
 
 @test "create_message.sh test too many arguments" {
     run ./create_message.sh "$EVENT_ID" "$ZIP_FILENAME" "/path/to/file" "$DATA_TYPE"
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
-    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <path> <data_type> <output_dir>"
+    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 }
 
 @test "cleanup_incomplete.sh cleanups incomplete directories" {


### PR DESCRIPTION
This PR Updates the format of the message file by removing the `path` variable and adding the zip files `md5sum`.

**New Message File Format**
```json
{
  "event_id": "10149",
  "filename": "kea-events-sel00-202406-10149.zip",
  "md5sum": "1234567890",
  "data_type": "events"
}
```

**Old Message File Format**
```json
{
  "event_id": "10149",
  "filename": "kea-events-sel00-202406-10149.zip",
  "path": "kea/events/2024-06/sel00",
  "data_type": "events"
}
```