### PR TITLE
Fix ssh_key_path in archive_pipeline script

### DIFF
--- a/cli_meter/archive_pipeline.sh
+++ b/cli_meter/archive_pipeline.sh
@@ -58,7 +58,7 @@ for i in $(seq 0 $((num_dirs - 1))); do
     if [ -d "$src_dir" ] && [ -n "$(ls -A "$src_dir")" ]; then
         log "Transfering data from: $src_dir to $dest_dir on $dest_host as $dest_user"
 
-        rsync -av -e 'ssh -i $ssh_key_path' --bwlimit=$bwlimit --exclude 'working' "$src_dir" "$dest_user@$dest_host:$dest_dir"
+        rsync -av -e "ssh -i $ssh_key_path" --bwlimit=$bwlimit --exclude 'working' "$src_dir" "$dest_user@$dest_host:$dest_dir"
         rsync_status=$?
 
         # Check the status of the rsync command


### PR DESCRIPTION
This PR fixes the `ssh_key_path` issue in `archive_pipeline.sh`, the below warning message should no longer exist.
**Fixed**
```bash
Aug 07 23:23:30 acep-kea-data-server archive_pipeline.sh[3039613]: Warning: Identity file $ssh_key_path not accessible: No such file or directory.
```