### PR TITLE
Script to sync Scada files to local system

### DIFF
--- a/cli_meter/common_utils.sh
+++ b/cli_meter/common_utils.sh
@@ -87,6 +87,16 @@ log() {
   echo "$1" >&2
 }
 
+function cleanup() {
+    echo "exiting..."
+    exit 0
+}
+
+function read_config() {
+    local key=$1
+    yq e ".$key" $CONFIG_FILE
+}
+
 parse_config_arg() {
   local config_path=""
 

--- a/cli_meter/config/scada-sync.yml.example
+++ b/cli_meter/config/scada-sync.yml.example
@@ -1,6 +1,6 @@
 # This file contains the configuration settings to sync scada data.
 
-source: 
+src_dir: 
 num_months: 
 ssh_key_path: 
 dest_user: 

--- a/cli_meter/config/scada-sync.yml.example
+++ b/cli_meter/config/scada-sync.yml.example
@@ -1,0 +1,8 @@
+# This file contains the configuration settings to sync scada data.
+
+source: 
+num_months: 
+ssh_key_path: 
+dest_user: 
+dest_host: 
+dest_dir: 

--- a/cli_meter/config/scada-sync.yml.example
+++ b/cli_meter/config/scada-sync.yml.example
@@ -2,7 +2,4 @@
 
 src_dir: 
 num_months: 
-ssh_key_path: 
-dest_user: 
-dest_host: 
 dest_dir: 

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-current_dir=$(dirname "$(readlink -f "$0")")
-script_name=$(basename "$0")
-source "$current_dir/common_utils.sh"
+CUR_DIR=$(dirname "$(readlink -f "$0")")
+SCRIPT_NAME=$(basename "$0")
+source "$CUR_DIR/common_utils.sh"
 
 # Trap to handle cleanup on exit
 trap cleanup INT
-LOCKFILE="/var/lock/$script_name"
+LOCKFILE="/var/lock/$SCRIPT_NAME"
 
 # Check for at least 1 argument
 [ "$#" -lt 1 ] && show_help_flag && failure $STREAMS_INVALID_ARGS "No arguments provided"

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -1,4 +1,21 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# ==============================================================================
+# Script Name:        sync-scada-data.sh
+# Description:        This script syncs SCADA data files from a source directory
+#                     to a destination directory over a specified number of months.
+#                     The script reads configuration values from a YAML file.
+#
+# Usage:              ./sync-scada-data.sh -c <config_path>
+#
+# Arguments:
+#   -c, --config       Path to the configuration file
+#   -h, --help         Show usage information
+#
+# Requirements:       yq
+#                     common_utils.sh
+# ==============================================================================
+
+
 CUR_DIR=$(dirname "$(readlink -f "$0")")
 SCRIPT_NAME=$(basename "$0")
 source "$CUR_DIR/common_utils.sh"

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -48,16 +48,15 @@ log "Syncing from $SRC_DIR to $DEST_DIR for the last $NUM_MONTHS months"
 # Loop over the number of months specified
 for ((i=0; i<NUM_MONTHS; i++)); do
     # Calculate the date for each month in the past
-    timestamp=$(date -d "$CUR_DATE -$i month" +%Y%m)
+    cur_timestamp=$(date -d "$CUR_DATE -$i month" +%Y%m)
 
     # Create the destination directory if it doesn't exist
-    dest_dir_path="$DEST_DIR/$timestamp"
+    dest_dir_path="$DEST_DIR/$cur_timestamp"
     
-    log "Syncing files for timestamp $timestamp to $dest_dir_path"
-
+    log "Syncing files for timestamp $cur_timestamp to $dest_dir_path"
 
     # Rsync all files for the current timestamp
-    rsync -av "$SRC_DIR"/*"$timestamp"* "${dest_dir_path}/"
+    rsync -av $SRC_DIR/*$cur_timestamp* $dest_dir_path
 done
 
 rsync_exit_code=$?

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -33,10 +33,6 @@ log "Syncing from $SRC_DIR to $DEST_DIR for the last $NUM_MONTHS months"
 # Calculate the timestamp for the given number of months
 END_DATE=$(date -d "$NUM_MONTHS months ago" +%Y%m%d)
 
-# Add the SSH key to the agent
-eval "$(ssh-agent -s)"
-ssh-add "$SSH_KEY_PATH"
-
 # Create an associative array to track which timestamps have been processed
 declare -A synced_timestamps
 
@@ -63,7 +59,3 @@ done
 
 rsync_exit_code=$?
 [ $rsync_exit_code -eq 0 ] && log "Sync from $SRC_DIR to $DEST_DIR complete" || failure $STREAMS_RSYNC_FAIL "Sync from $SRC_DIR to $DEST_DIR failed with exit code $rsync_exit_code"
-
-# Remove the SSH key from the agent
-ssh-agent -k
-

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -56,7 +56,7 @@ for ((i=0; i<NUM_MONTHS; i++)); do
     log "Syncing files for timestamp $cur_timestamp to $dest_dir_path"
 
     # Rsync all files for the current timestamp
-    rsync -av $SRC_DIR/*$cur_timestamp* $dest_dir_path
+    rsync -av ${SRC_DIR}/*${cur_timestamp}* $dest_dir_path
 done
 
 rsync_exit_code=$?

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -40,9 +40,6 @@ CONFIG_FILE=$(parse_config_arg "$@")
 # Read values from the YAML config
 SRC_DIR=$(read_config "src_dir")
 NUM_MONTHS=$(read_config "num_months")
-SSH_KEY_PATH=$(read_config "ssh_key_path")
-USER=$(read_config "dest_user")
-HOST=$(read_config "dest_host")
 DEST_DIR=$(read_config "dest_dir")
 CUR_DATE=$(date +%Y-%m-01)
 
@@ -55,12 +52,12 @@ for ((i=0; i<NUM_MONTHS; i++)); do
 
     # Create the destination directory if it doesn't exist
     dest_dir_path="$DEST_DIR/$timestamp"
-    ssh -i "$SSH_KEY_PATH" "$USER@$HOST" "mkdir -p $dest_dir_path"
     
     log "Syncing files for timestamp $timestamp to $dest_dir_path"
 
+
     # Rsync all files for the current timestamp
-    rsync -av -e "ssh -i $SSH_KEY_PATH" "$SRC_DIR"/*"$timestamp"* "$USER@$HOST:$dest_dir_path/"
+    rsync -av "$SRC_DIR"/*"$timestamp"* "${dest_dir_path}/"
 done
 
 rsync_exit_code=$?

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -21,7 +21,7 @@ CONFIG_FILE=$(parse_config_arg "$@")
 [ -f "$CONFIG_FILE" ] && log "Config file exists at: $CONFIG_FILE" || failure $STREAMS_FILE_NOT_FOUND "Config file does not exist"
 
 # Read values from the YAML config
-SRC_DIR=$(read_config "source")
+SRC_DIR=$(read_config "src_dir")
 NUM_MONTHS=$(read_config "num_months")
 SSH_KEY_PATH=$(read_config "ssh_key_path")
 USER=$(read_config "dest_user")

--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+# Trap to handle cleanup on exit
+trap cleanup INT
+
+function cleanup() {
+    echo "exiting..."
+    exit 0
+}
+
+# Function to read config values using yq
+function read_config() {
+    local key=$1
+    yq e ".$key" $CONFIG_FILE
+}
+
+CONFIG_FILE="$1"
+
+# Read values from the YAML config
+SRC_DIR=$(read_config "source")
+NUM_MONTHS=$(read_config "num_months")
+SSH_KEY_PATH=$(read_config "ssh_key_path")
+USER=$(read_config "dest_user")
+HOST=$(read_config "dest_host")
+DEST_DIR=$(read_config "dest_dir")
+
+echo "Syncing from $SRC_DIR to $DEST_DIR for the last $NUM_MONTHS months"
+
+# Calculate the timestamp for the given number of months
+END_DATE=$(date -d "$NUM_MONTHS months ago" +%Y%m%d)
+
+# Add the SSH key to the agent
+eval "$(ssh-agent -s)"
+ssh-add "$SSH_KEY_PATH"
+
+# Create an associative array to track which timestamps have been processed
+declare -A synced_timestamps
+
+# Iterate over files in the source directory
+for file in "$SRC_DIR"/*; do
+    # Extract the timestamp from the filename
+    timestamp=$(echo "$file" | cut -d' ' -f2 | cut -c1-6)
+    
+    # Check if the timestamp is within the desired range and not already processed
+    if [[ "$timestamp" > "${END_DATE:0:6}" ]] && [[ -z "${synced_timestamps[$timestamp]}" ]]; then
+        # Mark the timestamp as processed to avoid duplicate processing
+        synced_timestamps["$timestamp"]=1
+
+        # Create the destination directory if it doesn't exist
+        dest_dir_path="$DEST_DIR/$timestamp"
+        ssh -i "$SSH_KEY_PATH" "$USER@$HOST" "mkdir -p $dest_dir_path"
+
+        echo "Syncing files with timestamp $timestamp to $dest_dir_path"
+
+        # Rsync all files with the same timestamp in their filenames to timestamped dirs
+        rsync -av -e "ssh -i $SSH_KEY_PATH" "$SRC_DIR"/*"$timestamp"* "$USER@$HOST:$dest_dir_path/"
+    else
+        if [[ -z "${synced_timestamps[$timestamp]}" ]]; then
+            echo "Skipping file, timestamp $timestamp is already synced"
+        else
+            echo "Skipping file, $timestamp is outside the range"
+        fi
+    fi
+done
+
+# Kill the ssh-agent after the script runs
+ssh-agent -k
+
+echo "Syncing from $SRC_DIR to $DEST_DIR complete"


### PR DESCRIPTION
This PR introduces a new script, `sync-scada-data.sh`, which automates the syncing of SCADA data files from a source directory to a destination directory over a specified number of months. The script reads configuration values from a YAML file and ensures that data from the current month and previous months, as specified, are transferred correctly.

Changes:
1. Added sync-scada-data.sh:
    - Sets up environment and configurations.
    - Reads source directory, number of months, SSH key path, destination user, host, and directory from the configuration file.
    - Loops over the specified number of months, creating necessary directories and syncing files via rsync.

2. Added `scada-sync.yml.example`:
    - Example configuration file specifying:
      -  **src_dir**
      -  **num_months**
      -  **ssh_key_path**
      -  **dest_user**
      -  **dest_host** 
      - **dest_dir**

**Usage:**
1. **Configuration File:**
    - Update `scada-sync.yml` with the appropriate values for your environment.
2. **Running the Script**
```bash
./sync-scada-data.sh -c /path/to/scada-sync.yml
```