### PR TITLE
Create dest dir if it doesn't exist

### DIFF
--- a/cli_meter/sync-scada-data.sh
+++ b/cli_meter/sync-scada-data.sh
@@ -43,6 +43,8 @@ NUM_MONTHS=$(read_config "num_months")
 DEST_DIR=$(read_config "dest_dir")
 CUR_DATE=$(date +%Y-%m-01)
 
+mkdir -p $DEST_DIR
+
 log "Syncing from $SRC_DIR to $DEST_DIR for the last $NUM_MONTHS months"
 
 # Loop over the number of months specified


### PR DESCRIPTION
This PR updates `sync-scada-data.sh` to ensure that the dest_dir exists and if not is created. 