### PR TITLE
Added Meter ID/Name to MQTT message.

### DIFF
--- a/cli_meter/meters/sel735/create_message.sh
+++ b/cli_meter/meters/sel735/create_message.sh
@@ -7,6 +7,7 @@
 #                     <data_type> <output_dir>
 #
 # Arguments:
+#   meter_id          Meter ID
 #   event_id          event ID
 #   zip_filename      Name of the zipped file
 #   md5sum_value      md5sum of the zipped file
@@ -20,23 +21,25 @@ current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh" 
 
-# Check for exactly 5 arguments
-[ "$#" -ne 5 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
+# Check for exactly 6 arguments
+[ "$#" -ne 6 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 
-event_id="$1"
-zip_filename="$2"
-md5sum_value="$3"
-data_type="$4"
-output_dir="$5"
+meter_id="$1"
+event_id="$2"
+zip_filename="$3"
+md5sum_value="$4"
+data_type="$5"
+output_dir="$6"
 message_file="$output_dir/${zip_filename}.message"
 
 # Create the JSON payload
 json_payload=$(jq -n \
+    --arg mid "$meter_id" \
     --arg eid "$event_id" \
     --arg fn "$zip_filename" \
     --arg md5s "$md5sum_value" \
     --arg dt "$data_type" \
-    '{event_id: $eid, filename: $fn, md5sum: $md5s, data_type: $dt}')
+    '{meter_id: $mid, event_id: $eid, filename: $fn, md5sum: $md5s, data_type: $dt}')
 
 # Write the JSON payload to the .message file
 echo "$json_payload" > "$message_file" && log "Created message file: $message_file" || failure $STREAMS_FILE_CREATION_FAIL "Failed to write to message file: $message_file"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -147,7 +147,7 @@ for event_info in $events; do
   md5sum_value=$(md5sum "$event_zipped_output_dir/$zip_filename" | awk '{print $1}')
 
   # Create the message file (JSON) for the event
-  "$current_dir/create_message.sh" "$event_id" "$zip_filename" "$md5sum_value" "$data_type" "$event_zipped_output_dir" || {
+  "$current_dir/create_message.sh" "$meter_id" "$event_id" "$zip_filename" "$md5sum_value" "$data_type" "$event_zipped_output_dir" || {
     handle_fail "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id"  "$meter_id" "$download_start" "$download_end" 
     continue
   }

--- a/cli_meter/test/test_scripts.bats
+++ b/cli_meter/test/test_scripts.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "create_message.sh execution test" {
-    run ./create_message.sh "$EVENT_ID" "$ZIP_FILENAME" "/path/to/file" "$DATA_TYPE" "$TMP_DIR" 
+    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR"
     assert_success
     assert [ -f "$TMP_DIR/$ZIP_FILENAME.message" ]
 }
@@ -22,13 +22,13 @@ teardown() {
 @test "create_message.sh test 0 arguments" {
     run ./create_message.sh
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
-    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
+    assert_output --partial "Usage: create_message.sh <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 }
 
 @test "create_message.sh test too many arguments" {
-    run ./create_message.sh "$EVENT_ID" "$ZIP_FILENAME" "/path/to/file" "$DATA_TYPE"
+    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR" "extra_argument"
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
-    assert_output --partial "Usage: create_message.sh <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
+    assert_output --partial "Usage: create_message.sh <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 }
 
 @test "cleanup_incomplete.sh cleanups incomplete directories" {


### PR DESCRIPTION
This PR adds the meter ID directly to the MQTT message, allowing the Rails API to reliably link event files to their corresponding meters. Previously, this link was established by parsing the file path, which proved unreliable due to potential changes in the path structure. Including the meter ID in the message ensures a consistent and reliable reference, improving data integrity and reducing the risk of linkage errors.