### PR TITLE
Add event_timestamp to message file

### DIFF
--- a/cli_meter/meters/sel735/create_message.sh
+++ b/cli_meter/meters/sel735/create_message.sh
@@ -4,7 +4,7 @@
 # Description:        This script creates a .message file with a JSON payload.
 #
 # Usage:              ./create_message.sh <event_id> <zip_filename> <md5sum_value>
-#                     <data_type> <output_dir>
+#                     <data_type> <output_dir> <event_timestamp>
 #
 # Arguments:
 #   meter_id          Meter ID
@@ -13,6 +13,7 @@
 #   md5sum_value      md5sum of the zipped file
 #   data_type         Type of data
 #   output_dir        Directory where the message file will be stored
+#   event_timestamp   Timestamp of the event from the meter
 #
 # Requirements:       jq
 #                     common_utils.sh
@@ -21,8 +22,8 @@ current_dir=$(dirname "$(readlink -f "$0")")
 script_name=$(basename "$0")
 source "$current_dir/../../common_utils.sh" 
 
-# Check for exactly 6 arguments
-[ "$#" -ne 6 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
+# Check for exactly 7 arguments
+[ "$#" -ne 7 ] && failure $STREAMS_INVALID_ARGS "Usage: $script_name <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir> <event_timestamp>"
 
 meter_id="$1"
 event_id="$2"
@@ -30,6 +31,7 @@ zip_filename="$3"
 md5sum_value="$4"
 data_type="$5"
 output_dir="$6"
+event_timestamp="$7"
 message_file="$output_dir/${zip_filename}.message"
 
 # Create the JSON payload
@@ -39,7 +41,8 @@ json_payload=$(jq -n \
     --arg fn "$zip_filename" \
     --arg md5s "$md5sum_value" \
     --arg dt "$data_type" \
-    '{meter_id: $mid, event_id: $eid, filename: $fn, md5sum: $md5s, data_type: $dt}')
+    --arg et "$event_timestamp" \
+    '{meter_id: $mid, event_id: $eid, filename: $fn, md5sum: $md5s, data_type: $dt, event_timestamp: $et}')
 
 # Write the JSON payload to the .message file
 echo "$json_payload" > "$message_file" && log "Created message file: $message_file" || failure $STREAMS_FILE_CREATION_FAIL "Failed to write to message file: $message_file"

--- a/cli_meter/meters/sel735/download.sh
+++ b/cli_meter/meters/sel735/download.sh
@@ -147,7 +147,7 @@ for event_info in $events; do
   md5sum_value=$(md5sum "$event_zipped_output_dir/$zip_filename" | awk '{print $1}')
 
   # Create the message file (JSON) for the event
-  "$current_dir/create_message.sh" "$meter_id" "$event_id" "$zip_filename" "$md5sum_value" "$data_type" "$event_zipped_output_dir" || {
+  "$current_dir/create_message.sh" "$meter_id" "$event_id" "$zip_filename" "$md5sum_value" "$data_type" "$event_zipped_output_dir" "$event_timestamp" || {
     handle_fail "$event_id" "$output_dir" "$STREAMS_FILE_CREATION_FAIL" "Failed to create message file for event: $event_id"  "$meter_id" "$download_start" "$download_end" 
     continue
   }

--- a/cli_meter/test/test_helper/common.bash
+++ b/cli_meter/test/test_helper/common.bash
@@ -20,6 +20,7 @@ _common_setup() {
     DATA_TYPE="events"
     SYMLINK_NAME="$LOCATION-$METER_TYPE-$METER_ID-YYYYMM-$EVENT_ID"
     ZIP_FILENAME="${SYMLINK_NAME}.zip"
+    EVENT_TIMESTAMP="2021-01-01T00:00:00Z"
 }
 
 _common_teardown() {

--- a/cli_meter/test/test_scripts.bats
+++ b/cli_meter/test/test_scripts.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "create_message.sh execution test" {
-    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR"
+    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR" "$EVENT_TIMESTAMP"
     assert_success
     assert [ -f "$TMP_DIR/$ZIP_FILENAME.message" ]
 }
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "create_message.sh test too many arguments" {
-    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR" "extra_argument"
+    run ./create_message.sh "$METER_ID" "$EVENT_ID" "$ZIP_FILENAME" "$MD5SUM_VALUE" "$DATA_TYPE" "$TMP_DIR" "$EVENT_TIMESTAMP" "extra_argument"
     assert_failure $(($STREAMS_INVALID_ARGS % 256))
     assert_output --partial "Usage: create_message.sh <meter_id> <event_id> <zip_filename> <md5sum_value> <data_type> <output_dir>"
 }


### PR DESCRIPTION
This PR adds the `event_timestamp` to the message file and update tests to reflect new argument. Will have to write script to add `event_timestamp` to existing files.